### PR TITLE
implement delayed jobs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -52,6 +52,30 @@ jobs.create('email', {
 };
 ```
 
+### Delayed Jobs
+
+  Sometimes you want to delay jobs to be executed after a certain timespan. `create()` supports a third parameter with a timestamp when the
+  job should be executed. This is the minimum point of time and may vary depending on your job queue. If the job has a delay and high priority, the job
+  is very likely to run on near the specified point in time. This example starts the email job, 30 seconds in future.
+
+```js
+jobs.create('email', {
+    title: 'welcome email for tj'
+  , to: 'tj@learnboost.com'
+  , template: 'welcome-email'
+}, new Date().getTime() + 30000).priority('high').save();
+```
+
+  This requires that the `jobs.promote([timestamp])` function is regulary executed on at least one node. One easy way is to use your master process and
+  schedule a regular call:
+
+```js
+setInterval(jobs.promote, 2000);
+```
+
+  The promote function moves all jobs that are realy for running into the queue. From their they will take a normal path. Please consider that the promote
+  intervall is setting additional delay on the specified point in time.
+
 ### Failure Attempts
 
  By default jobs only have _one_ attempt, that is when they fail, they are marked as a failure, and remain that way until you intervene. However, Kue allows you to specify this, which is important for jobs such as transferring an email, which upon failure, may usually retry without issue. To do this invoke the `.attempts()` method with a number.

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -75,8 +75,8 @@ Queue.prototype.__proto__ = EventEmitter.prototype;
  */
 
 Queue.prototype.create =
-Queue.prototype.createJob = function(type, data){
-  return new Job(type, data);
+Queue.prototype.createJob = function(type, data, after){
+  return new Job(type, data, after);
 };
 
 /**
@@ -119,6 +119,65 @@ Queue.prototype.process = function(type, n, fn){
     })(new Worker(this, type).start(fn));
   }
 };
+
+/**
+ * Promotes jobs from queue
+ *
+ * @param {timestamp} promotes jobs smaller then timestamp
+ * @api public
+ */
+
+Queue.prototype.promote = function(timestamp){
+  var client = this.client,
+      self = this;
+
+  var limit = 30;
+
+  if (typeof(timestamp) == 'undefined')
+    timestamp = new Date().getTime();
+
+  var promoted = [];
+  
+  function promo_log() {
+    if(promoted.length > 0)
+      console.log("kue promoted " + promoted.length + " job(s): " + promoted.join(","));
+  }
+
+  function promote_chunks() {
+    client.sort('q:jobs:wait', 'by', 'q:job:after:*', 'limit', '0', limit, 'asc',
+      function(err, sorted) {
+        // no jobs todo
+        if(err || !sorted || sorted.length == 0) {
+          promo_log();
+          return;
+        }
+
+        args = sorted.map(function(i) { return "q:job:after:" + i})
+
+        // callback is last parameter call
+        args.push(function xstamps(err, stamps) {
+          for(i = 0; i < limit; i++) {
+            if(stamps[i] <= timestamp) {
+              // promote job
+              promoted.push(sorted[i]);
+              Job.get(sorted[i], function(err, job) {
+                job.inactive()
+              })
+            } else {
+               // only older entries exist
+               promo_log();
+               return;
+            }
+          }
+          promote_chunks();
+        });
+        client.mget.apply(client, args);
+      }
+    );
+  }
+  promote_chunks();
+};
+
 
 /**
  * Get the job types present and callback `fn(err, types)`.

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -146,6 +146,7 @@ exports.get = function(id, fn){
     job._progress = hash.progress;
     job._attempts = hash.attempts;
     job._max_attempts = hash.max_attempts;
+    job.after = hash.after;
     job.state = hash.state;
     job._error = hash.error;
     job.created_at = hash.created_at;
@@ -196,11 +197,13 @@ exports.log = function(id, fn){
  *
  * @param {String} type
  * @param {Object} data
+ * @param {Timestamp} queue after timestamp
  * @api public
  */
 
-function Job(type, data) {
+function Job(type, data, after) {
   this.type = type;
+  this.after = after;
   this.data = data || {};
   this.client = pool.alloc();
   this.priority('normal');
@@ -225,6 +228,7 @@ Job.prototype.toJSON = function(){
     , created_at: this.created_at
     , updated_at: this.updated_at
     , failed_at: this.failed_at
+    , after: this.after
     , duration: this.duration
     , attempts: {
         made: this._attempts
@@ -281,6 +285,9 @@ Job.prototype.log = function(str){
 
 Job.prototype.set = function(key, val, fn){
   this.client.hset('q:job:' + this.id, key, val, fn || noop);
+  if(key == "after") {
+      this.client.set('q:job:after:' + this.id, val);
+  }
   return this;
 };
 
@@ -368,8 +375,8 @@ Job.prototype.attempts = function(n){
  */
 
 Job.prototype.removeStatus = function(status, fn){
-  this.client.zrem('q:jobs', this.id);
-  this.client.zrem('q:jobs:' + status, this.id);
+  this.client.zrem('q:jobs', this.id, noop);
+  this.client.zrem('q:jobs:' + status, this.id, noop);
   this.client.zrem('q:jobs:' + this.type + ':' + status, this.id, fn || noop);
   return this;
 };
@@ -406,10 +413,14 @@ Job.prototype.status = function(status){
   this.removeStatus('failed');
   this.removeStatus('inactive');
   this.removeStatus('active');
+  this.removeStatus('wait');
   this.set('state', status);
   this.client.zadd('q:jobs', this._priority, this.id);
   this.client.zadd('q:jobs:' + status, this._priority, this.id);
   this.client.zadd('q:jobs:' + this.type + ':' + status, this._priority, this.id);
+  if(status != "wait")
+      this.client.del('q:jobs:after:' + this.id)
+ 
   return this;
 };
 
@@ -456,17 +467,20 @@ Job.prototype.save = function(fn){
   var client = this.client
     , fn = fn || noop
     , max = this._max_attempts
+    , after = this.after
     , self = this;
 
   // update
   if (this.id) return this.update(fn);
 
   // incr id
+
   client.incr('q:ids', function(err, id){
     if (err) return fn(err);
     var key = 'q:job:' + id;
     self.id = id;
-    self.state = 'inactive';
+    self.state = self.after ? 'wait' : 'inactive';
+    if (after) client.set('q:job:after:' + id, after);
     if (max) client.hset(key, 'max_attempts', max);
     client.sadd('q:job:types', self.type);
     self.set('type', self.type);


### PR DESCRIPTION
Delayed executions allows you to run jobs at a specific time in future.
This allows you for example to rerun jobs with longer delays on failure
or plan tasks so they don't stress so much. Delayed jobs need at least
one process calling promote() on an intervall.
implement delayed jobs
