### PR TITLE
Minor readme touch-up

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -92,8 +92,7 @@ job.progress(frames, totalFrames);
 
 ### Job Events
 
- Job-specific events are fired are fire on the `Job` instances themselves
- via Redis pubsub. The following events are currently supported:
+ Job-specific events are fired on the `Job` instances via Redis pubsub. The following events are currently supported:
 
     - `failed` the job has failed
     - `complete` the job has completed
@@ -120,7 +119,7 @@ job.on('complete', function(){
 
 ### Delayed Jobs
 
-  Delayed jobs may be scheduled to be queued for an arbitrary distance in tim by invoking the `.delay(ms)` method, passing the number of milliseconds relative to _now_. This automatically flags the `Job` as "delayed". 
+  Delayed jobs may be scheduled to be queued for an arbitrary distance in time by invoking the `.delay(ms)` method, passing the number of milliseconds relative to _now_. This automatically flags the `Job` as "delayed". 
 
 ```js
 var email = jobs.create('email', {


### PR DESCRIPTION
from:

are fired are fire on the `Job` instances themselves

to:

are fired on the `Job` instances themselves
