### PR TITLE
add resource limitations

### DIFF
--- a/examples/ressources.js
+++ b/examples/ressources.js
@@ -1,0 +1,48 @@
+
+var kue = require('../')
+  , express = require('express');
+
+// create our job queue
+
+var jobs = kue.createQueue();
+jobs.clearResources(["test:a"], function(err, bla) { console.log(err, bla)});
+
+function create() {
+  var name = ['tobi', 'loki', 'jane', 'manny'][Math.random() * 4 | 0];
+  jobs.create('test', {
+      title: 'converting ' + name + '\'s to avi'
+    , user: 1
+    , frames: 200
+  }).save();
+  setTimeout(create, Math.random() * 3000 | 0);
+}
+
+jobs.setLimits(
+        {"test:a" : 20}, 
+        function(err, res) {
+            console.log("limits", err, res)
+            create();
+        });
+
+// process video conversion jobs, 3 at a time.
+
+jobs.process('test', 2, function(job, done){
+  process.stdout.write(".");
+  job.useResources(
+    {"test:a":20, 
+     "test:x:le":1},
+    30000,
+    function() {
+      console.log('DO WORK');
+      setTimeout(done, Math.random() * 5000);
+    }
+  );
+});
+
+// process 10 emails at a time
+
+// start the UI
+kue.app.listen(3000);
+console.log('UI started on port 3000');
+
+jobs.promote(1000);

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -157,7 +157,6 @@ Queue.prototype.promote = function(ms){
 
 /**
  * Get setting `name` and invoke `fn(err, res)`.
- *
  * @param {String} name
  * @param {Function} fn
  * @return {Queue} for chaining
@@ -166,8 +165,72 @@ Queue.prototype.promote = function(ms){
 
 Queue.prototype.setting = function(name, fn){
   this.client.hget('q:settings', name, fn);
+   return this;
+ };
+
+
+/**
+ * updates resources limits.
+ *
+ * @param {Object} key/value object of limits to set
+ * @param {Function} fn
+ * @return {Queue} for chaining
+ * @api public
+ */
+
+Queue.prototype.setLimits = function(limits, fn){
+  this.client.hmset('q:limits', limits, fn || function () {});
   return this;
 };
+
+/**
+ * clear ressource limits.
+ *
+ * @param {Array} list of limits to clear
+ * @param {Function} fn
+ * @return {Queue} for chaining
+ * @api public
+ */
+
+Queue.prototype.clearLimits = function(limits, fn){
+  var exe = this.client.multi();
+  for(var i = 0; i < limits.length; i ++)
+      exe.hdel('q:limits', limits[i]);
+  exe.exec(fn || function() {});
+  return this;
+};
+
+/**
+ * deletes ressource limits.
+ *
+ * @param {Array} list of limits to clear
+ * @param {Function} fn
+ * @return {Queue} for chaining
+ * @api public
+ */
+
+Queue.prototype.clearResources = function(resources, fn){
+  var exe = this.client.multi();
+  for(var i = 0; i < resources.length; i ++)
+      exe.hdel('q:resources', resources[i]);
+  exe.exec(fn || function() {});
+  return this;
+};
+
+/**
+ * clears all ressource limits.
+ *
+ * @param {Array} list of limits to clear
+ * @param {Function} fn
+ * @return {Queue} for chaining
+ * @api public
+ */
+
+Queue.prototype.clearAllResources = function(fn){
+  this.client.del("q:resources", fn || function() {});
+  return this;
+};
+
 
 /**
  * Process jobs with the given `type`, invoking `fn(job)`.

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -44,6 +44,7 @@ var priorities = exports.priorities = {
   , critical: -15
 };
 
+
 /**
  * Map `jobs` by the given array of `ids`.
  *
@@ -217,6 +218,7 @@ exports.log = function(id, fn){
 function Job(type, data) {
   this.type = type;
   this.data = data || {};
+  this.resources = {};
   this.client = pool.alloc();
   this.priority('normal');
 }
@@ -338,6 +340,162 @@ Job.prototype.delay = function(ms){
   this._state = 'delayed';
   return this;
 };
+
+
+/**
+ * generate a list of ressources limiters that could match to given resource
+ * @api private
+ */
+function generate_limit_request(res) {
+    var chunks = res.split(":");
+    rv = [res]
+    for(var i = 2; i <= chunks.length; i++) {
+        rv.push(chunks.slice(0, i-1).concat(["__default__"]).join(":"));
+    }
+    return rv;
+}
+
+/**
+ * Test if the ressource used hits any limit
+ * @api private
+ */
+function test_limits(res, used, limits) {
+    var chunks = res.split(),
+        over_limit = "";
+
+    for(var i = chunks.length; i > 0; i--) {
+        var key = chunks.slice(0, i).join(":");
+
+        if (limits[key] !== null) {
+          var climit = Number(limits[key]);
+          if (used > climit && climit > 0)
+            return key + "=" + used + ">" + climit;
+
+        } else if(i > 0) {
+          key = chunks.slice(0, i-1).concat(["__default__"]).join(":");
+          if (limits[key] !== null) {
+            var climit = Number(limits[key]);
+            if (used > climit && climit > 0)
+              return key + "=" + used + ">" + climit;
+          }
+        }
+    }
+    return over_limit || false;
+}
+
+
+/**
+ * Allocate resources for beeing used by the job. If the ressources do not
+ * match the criteria, the callback is not run and the job delayed.
+ * done needs to be your done function.
+ *
+ * @param resources to use when calling the function
+ * @param Callback run with allocated resources
+ * @return {Job|Number}
+ * @api public
+ */
+Job.prototype.useResources = function(resources, delay, callback){
+  if (typeof(callback) != 'function')
+    return this.resources;
+
+  // get the limits set in the database
+
+  var limit_requests = [];
+  var allocate = {};
+  var allocate_list = [];
+
+  for (res in resources) {
+    limit_requests = limit_requests.concat(generate_limit_request(res))
+    allocate[res] = resources[res] || 1;
+  }
+  limit_requests.push("__default__");
+
+  var exe = this.client.multi().hmget("q:limits", limit_requests);
+
+  for (key in allocate) {
+    exe = exe.hincrby("q:resources", key, allocate[key]);
+    allocate_list.push(key);
+  }
+
+  var self = this;
+  // allocate resources
+  exe.exec(function(err, res) {
+    // check ressources
+    if(err) {
+        this.log("error executing ressource allocation:" + err)
+        this.state('delayed').delay(30000);
+        return self._done("kue: requeue");
+    }
+
+    // update limits list
+    var limits = {};
+    for(var i = 0; i < res[0].length; i++)
+      limits[limit_requests[i]] = res[0][i];
+
+    // update resources list
+    self.resources = allocate;
+    var over_limit = false;
+    for(var i = 1; i < res.length; i++) {
+      var key = allocate_list[i-1];
+
+      over_limit = test_limits(key, res[i], limits);
+      if(over_limit)
+        break;
+    }
+    if(over_limit && delay > 0) {
+      self.log("ressource limitation hit: " + over_limit);
+      self.state('delayed').delay(delay).save();
+      return self._done("kue: requeue");
+    } else {
+      callback();
+    }
+  });
+  return this;
+};
+
+/**
+ * Frees allocated resources
+ **/
+
+Job.prototype.freeResources = function(callback){
+  if (typeof(callback) != 'function')
+    return this.resources;
+
+  // get the limits set in the database
+
+  var limit_requests = [];
+  var allocate = {};
+
+  var exe = this.client.multi();
+  released = [];
+  for (key in this.resources) {
+    exe = exe.hincrby("q:resources", key, -1 * this.resources[key]);
+    released.push(key);
+  }
+  var self = this;
+
+  exe.exec(function(err, res) {
+    if(err)
+      return callback(err, null);
+
+    // clear allocated ressources
+    self.resources = {}
+    var exe = self.client.multi();
+
+    for(var i=0; i < released.length; i++) {
+      if(res[i] <= 0) {
+        exe.hdel("q:resources", released[i]);
+      }
+    }
+    if(exe.queue.length > 1) {
+      exe.exec(function(err, res) {callback(null, null);});
+    } else {
+      callback(null, null);
+    }
+  });
+};
+
+
 
 /**
  * Set or get the priority `level`, which is one

--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -34,6 +34,51 @@ function Worker(queue, type) {
   this.type = type;
   this.client = Worker.client || (Worker.client = redis.createClient());
   this.interval = 1000;
+  this.active_jobs = [];
+  this._exit = false;
+
+  self = this;
+  // we try our best to free resources when node goes down
+  process.on('SIGTERM', this.emergencyRelease);
+  process.on('SIGINT', this.emergencyRelease);
+  process.on('exit', function() { self.emergencyRelease(true);});
+}
+
+/**
+ * emergencyRelease of allocated resources of the current running jobs.
+ * Is called when a deadly signal is received, but may be usefull when
+ * jobserver goes down. 
+ *
+ * @api public
+ */
+
+Worker.prototype.emergencyRelease = function(in_exit) {
+  var todo = 0;
+  this._exit = true;
+
+  done = function() {
+    todo = todo - 1;
+    if(todo < 1) { setTimeout(process.exit, 0); }
+  }
+
+  for(var i = 0; i < self.active_jobs.length; i++) {
+    var djob = self.active_jobs[i];
+
+    // no need for jobs without resources
+    if (Object.keys(djob.resources).length == 0)
+      continue;
+
+    todo += 1;
+    // fire in parallel
+    setTimeout(function() { djob.freeResources(done); }, 0);
+  }
+
+  if(todo == 0 && !in_exit)
+    process.exit(0);
+  else if(todo)
+    console.log("kue: emergency ressource release of " + todo + " jobs");
+  //setTimeout(function() { process.exit(0); },200);
+  return false;
 }
 
 /**
@@ -53,6 +98,8 @@ Worker.prototype.__proto__ = EventEmitter.prototype;
 
 Worker.prototype.start = function(fn){
   var self = this;
+  if(self._exit)
+    return this;
   self.getJob(function(err, job){
     if (err) self.error(err, job);
     if (!job || err) return setTimeout(function(){ self.start(fn); }, self.interval);
@@ -116,15 +163,26 @@ Worker.prototype.failed = function(job, err, fn){
 Worker.prototype.process = function(job, fn){
   var self = this
     , start = new Date;
+  self.active_jobs.push(job);
   job.active();
-  fn(job, function(err){
-    if (err) return self.failed(job, err, fn);
-    job.complete();
-    job.set('duration', job.duration = new Date - start);
-    self.emit('job complete', job);
-    events.emit(job.id, 'complete');
-    self.start(fn);
-  });
+  done = function(err){
+    // ensure the resources are freed on the end of the job
+    job.freeResources(function() {
+        self.active_jobs.splice(self.active_jobs.indexOf(job), 1);
+
+        if (err === "kue: requeue") return self.start(fn);
+        if (err) return self.failed(job, err, fn);
+
+        job.complete();
+        job.set('duration', job.duration = new Date - start);
+        self.emit('job complete', job);
+        events.emit(job.id, 'complete');
+        self.start(fn);
+    });
+  }
+  // for useResources
+  job._done = done;
+  fn(job, done);
   return this;
 };
 


### PR DESCRIPTION
With this patch, you can now manage resources jobs and prevent that jobs limiting the same resource can slow down processing.
Example usage:
- if you connect to a remote host you could set a limit on the host, and therefor prevent that the remote host get dosed by having to many jobs connect to a specific host.
- If a job is causing high io on a remote host but the job may run on any worker node, resource limitations prevent that too many jobs accessing a particular host may slow down overall job processing.

resources calculation is done on the job handler and can therefor calculate the resources needed.
