### PR TITLE
prevent continuously restarting the processing by each single worker

### DIFF
--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -123,7 +123,6 @@ Worker.prototype.process = function(job, fn){
     job.set('duration', job.duration = new Date - start);
     self.emit('job complete', job);
     events.emit(job.id, 'complete');
-    self.start(fn);
   });
   return this;
 };


### PR DESCRIPTION
When you do jobs.process('type', n, function(job, done){}), the n parameter should indicate how many jobs are fetched from the queue and processed.

However, no matter the value of n, always all of the queued jobs are processed.

In Queue.prototype.process, n workers are started, Worker.prototype.start calls Worker.prototype.process, and then in each worker, Worker.prototype.process calls self.start again...

Without the call to self.start from Worker.prototype.progress, behaviour is as expected: n workers will each process 1 jobs from the queue.
