### PR TITLE
Use 'exports.createClient' because that's the function the user modifies 

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,4 +1,3 @@
-
 /*!
  * kue - RedisClient factory
  * Copyright (c) 2011 LearnBoost <tj@learnboost.com>
@@ -31,7 +30,7 @@ exports.createClient = function(){
  */
 
 exports.client = function(){
-  return exports._client || (exports._client = redis.createClient());
+  return exports._client || (exports._client = exports.createClient());
 };
 
 /**


### PR DESCRIPTION
Use 'exports.createClient' because that's the function the user modifies to set host:port

Otherwise user choices have no effect.
