### PR TITLE
Use relative stats route

### DIFF
--- a/lib/http/public/javascripts/main.js
+++ b/lib/http/public/javascripts/main.js
@@ -235,7 +235,7 @@ function refreshJobs(state, fn) {
  */
 
 function pollStats(ms) {
-  request('/stats', function(data){
+  request('./stats', function(data){
     o('li.inactive .count').text(data.inactiveCount);
     o('li.active .count').text(data.activeCount);
     o('li.complete .count').text(data.completeCount);


### PR DESCRIPTION
Prior to this fix all requests to the stats route failed when kue was mounted at a subdirectory:

``` javascript
// stats requests go to /stats rather than /kue/stats
require('express')
  .createServer()
  .use('/kue', kue.app)
  .listen(8080);
```
