### PR TITLE
Set job data before setting its state

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -566,11 +566,11 @@ Job.prototype.update = function(fn){
   // priority
   this.set('priority', this._priority);
 
-  // state
-  this.state(this._state);
-
   // data
   this.set('data', json, fn);
+
+  // state
+  this.state(this._state);
 
   // search data
   getSearch().index(json, this.id);


### PR DESCRIPTION
Since setting state to inactive signals worker that there is a new job
ready we ensure that workers get the job after its data has been set
