### PR TITLE
QoS extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 *.sock
 testing
 lib/http/public/stylesheets/main.css
+
+.project
+.settings/

--- a/examples/QoS.js
+++ b/examples/QoS.js
@@ -1,0 +1,106 @@
+
+var kue = require('../')
+  , express = require('express');
+
+// create our job queue
+
+var jobs = kue.createQueue();
+jobs.watchdog();
+
+// start redis with $ redis-server
+
+// create some jobs at random,
+// usually you would create these
+// in your http processes upon
+// user input etc.
+
+var count = 1000;
+
+function create() {
+  if(count-- <= 0 ) return;
+  
+  var name = ['tobi', 'loki', 'jane', 'manny'][Math.random() * 4 | 0];
+  console.log('- creating job for %s', name);
+
+  var stage1 = null, stage2 = null;
+  
+  stage1 = jobs.create('video conversion', {
+      title: 'converting ' + name + '\'s to avi'
+    , user: 1
+    , frames: 200
+  }).heartbeat(10000).save(function(err){
+	  stage2 = jobs.create('video conversion', {
+	      title: 'converting ' + name + '\'s to mpeg'
+	    , user: 1
+	    , frames: 200
+	  }).heartbeat(10000).save(function(err){
+		  jobs.create('video analysis', {
+		      title: 'analyzing ' + name + '\'s avi'
+		    , user: 1
+		    , frames: 200
+		  }).heartbeat(10000).after(stage2).serialize('analysis').save();
+		  
+		  jobs.create('video analysis', {
+		      title: 'analyzing ' + name + '\'s avi and mpeg'
+		    , user: 1
+		    , frames: 200
+		  }).heartbeat(10000).after(stage1).after(stage2).serialize('analysis').save();
+	  });	  
+  });
+
+  setTimeout(create, Math.random() * 3000 | 0);
+}
+
+if(process.argv.length > 2) {
+	count = Number(process.argv[2]);
+	create();
+}
+else
+	console.log('usage: node QoS.js [<number-of-jobs>]');
+
+// process video analysis jobs, 6 at a time.
+
+jobs.process('video analysis', 6, function(job, done){
+  var frames = job.data.frames;
+  console.log("job process %d", job.id);
+  function next(i) {
+    // pretend we are doing some work
+    convertFrame(i, function(err){
+      if (err) return done(err);
+      // report progress, i/frames complete
+      job.progress(i, frames);
+      if (i == frames) done();
+      else next(i + 1);
+    });
+  }
+  next(0);
+});
+
+//process video conversion jobs, 4 at a time.
+
+jobs.process('video conversion', 4, function(job, done){
+  var frames = job.data.frames;
+  console.log("job process %d", job.id);
+  function next(i) {
+    // pretend we are doing some work
+    convertFrame(i, function(err){
+      if (err) return done(err);
+      // report progress, i/frames complete
+      job.progress(i, frames);
+      if (i == frames) done();
+      else next(i + 1);
+    });
+  }
+  next(0);
+});
+
+function convertFrame(i, fn) {
+  setTimeout(fn, Math.random() * 100);
+}
+
+// start the UI
+var app = express.createServer();
+app.use(express.basicAuth('foo', 'bar'));
+app.use(kue.app);
+app.listen(3000);
+console.log('UI started on port 3000');

--- a/examples/QoS.js
+++ b/examples/QoS.js
@@ -38,13 +38,13 @@ function create() {
 		      title: 'analyzing ' + name + '\'s avi'
 		    , user: 1
 		    , frames: 200
-		  }).heartbeat(10000).after(stage2).serialize('analysis').save();
+		  }).heartbeat(10000).serialize('analysis').save();
 		  
 		  jobs.create('video analysis', {
 		      title: 'analyzing ' + name + '\'s avi and mpeg'
 		    , user: 1
 		    , frames: 200
-		  }).heartbeat(10000).after(stage1).after(stage2).serialize('analysis').save();
+		  }).heartbeat(10000).serialize('analysis').save();
 	  });	  
   });
 

--- a/examples/video.js
+++ b/examples/video.js
@@ -37,7 +37,7 @@ jobs.process('video conversion', 3, function(job, done){
       if (err) return done(err);
       // report progress, i/frames complete
       job.progress(i, frames);
-      if (i == frames) done()
+      if (i == frames) done();
       else next(i + 1);
     });
   }

--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -66,7 +66,6 @@ app.del('/job/:id', provides('json'), json.remove);
 
 app.get('/', routes.jobs('active'));
 app.get('/delayed', routes.jobs('delayed'));
-app.get('/waiting', routes.jobs('waiting'));
 app.get('/staged', routes.jobs('staged'));
 app.get('/inactive', routes.jobs('inactive'));
 app.get('/active', routes.jobs('active'));

--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -65,8 +65,10 @@ app.del('/job/:id', provides('json'), json.remove);
 // routes
 
 app.get('/', routes.jobs('active'));
-app.get('/active', routes.jobs('active'));
+app.get('/delayed', routes.jobs('delayed'));
+app.get('/waiting', routes.jobs('waiting'));
+app.get('/staged', routes.jobs('staged'));
 app.get('/inactive', routes.jobs('inactive'));
+app.get('/active', routes.jobs('active'));
 app.get('/failed', routes.jobs('failed'));
 app.get('/complete', routes.jobs('complete'));
-app.get('/delayed', routes.jobs('delayed'));

--- a/lib/http/middleware/provides.js
+++ b/lib/http/middleware/provides.js
@@ -11,5 +11,5 @@ module.exports = function(type){
   return function(req, res, next){
     if (req.accepts(type)) return next();
     next('route');
-  }
+  };
 };

--- a/lib/http/public/javascripts/caustic.js
+++ b/lib/http/public/javascripts/caustic.js
@@ -230,7 +230,7 @@ View.prototype.visitDIV = function(el, name){
   var self = this;
   this[name] = function(val){
     if (0 == arguments.length) return el;
-    el.empty().append(val.el || val);
+    el.empty().append((val && val.el) ? val.el : val);
     return this;
   };
 };

--- a/lib/http/public/javascripts/job.js
+++ b/lib/http/public/javascripts/job.js
@@ -199,7 +199,13 @@ Job.prototype.renderUpdate = function(){
     view.restarts().parent().remove();
   }
 
-  // precurspors
+  // precursors
+  if (this.precursors) {
+	    view.precursors(this.precursors);
+	  } else {
+	    view.precursors().parent().remove();
+	  }
+
   if (this.after) {
     view.after(this.after);
   } else {

--- a/lib/http/public/javascripts/job.js
+++ b/lib/http/public/javascripts/job.js
@@ -192,6 +192,20 @@ Job.prototype.renderUpdate = function(){
     view.attempts().parent().remove();
   }
 
+  // restarts
+  if (this.restarts.made) {
+    view.restarts(this.restarts.made + '/' + this.restarts.max);
+  } else {
+    view.restarts().parent().remove();
+  }
+
+  // precurspors
+  if (this.after) {
+    view.after(this.after);
+  } else {
+    view.after().parent().remove();
+  }
+
   // title
   view.title(this.data.title
     ? this.data.title

--- a/lib/http/public/javascripts/main.js
+++ b/lib/http/public/javascripts/main.js
@@ -59,11 +59,13 @@ function init(state) {
 
   pollStats(1000);
   show(state)();
+  o('li.delayed a').click(show('delayed'));
+  o('li.waiting a').click(show('waiting'));
+  o('li.staged a').click(show('staged'));
   o('li.inactive a').click(show('inactive'));
   o('li.complete a').click(show('complete'));
   o('li.active a').click(show('active'));
   o('li.failed a').click(show('failed'));
-  o('li.delayed a').click(show('delayed'));
 
   o('#filter').change(function(){
     filter = $(this).val();
@@ -236,11 +238,13 @@ function refreshJobs(state, fn) {
 
 function pollStats(ms) {
   request('./stats', function(data){
+    o('li.delayed .count').text(data.delayedCount);
+    o('li.waiting .count').text(data.waitingCount);
+    o('li.staged .count').text(data.stagedCount);
     o('li.inactive .count').text(data.inactiveCount);
     o('li.active .count').text(data.activeCount);
     o('li.complete .count').text(data.completeCount);
     o('li.failed .count').text(data.failedCount);
-    o('li.delayed .count').text(data.delayedCount);
     setTimeout(function(){
       pollStats(ms);
     }, ms);

--- a/lib/http/public/javascripts/main.js
+++ b/lib/http/public/javascripts/main.js
@@ -45,6 +45,8 @@ var sort = 'asc';
 
 var loading;
 
+var pollInterval = 1000;
+
 /**
  * Initialize UI.
  */
@@ -57,10 +59,9 @@ function init(state) {
   loading.ctx = ctx;
   loading.size(canvas.width);
 
-  pollStats(1000);
+  pollStats(pollInterval);
   show(state)();
   o('li.delayed a').click(show('delayed'));
-  o('li.waiting a').click(show('waiting'));
   o('li.staged a').click(show('staged'));
   o('li.inactive a').click(show('inactive'));
   o('li.complete a').click(show('complete'));
@@ -143,7 +144,7 @@ function show(state) {
     o('#jobs .job').remove();
     o('#menu li a').removeClass('active');
     o('#menu li.' + state + ' a').addClass('active');
-    pollForJobs(state, 2000);
+    pollForJobs(state, pollInterval);
     return false;
   }
 }
@@ -161,7 +162,7 @@ function pollForJobs(state, ms) {
     infiniteScroll();
     pollForJobs.timer = setTimeout(function(){
       pollForJobs(state, ms);
-    }, 1000);
+    }, pollInterval);
   });
 };
 
@@ -239,7 +240,6 @@ function refreshJobs(state, fn) {
 function pollStats(ms) {
   request('./stats', function(data){
     o('li.delayed .count').text(data.delayedCount);
-    o('li.waiting .count').text(data.waitingCount);
     o('li.staged .count').text(data.stagedCount);
     o('li.inactive .count').text(data.inactiveCount);
     o('li.active .count').text(data.activeCount);

--- a/lib/http/public/javascripts/utils.js
+++ b/lib/http/public/javascripts/utils.js
@@ -36,11 +36,13 @@ function relative(ms) {
  */
 
 var states = {
-    active: 'active'
+	delayed: 'delayed'
   , inactive: 'inactive'
+  , waiting: 'waiting'
+  , staged: 'staged'
+  , active: 'active'
   , failed: 'failed'
   , complete: 'complete'
-  , delayed: 'delayed'
 };
 
 /**

--- a/lib/http/public/javascripts/utils.js
+++ b/lib/http/public/javascripts/utils.js
@@ -38,7 +38,6 @@ function relative(ms) {
 var states = {
 	delayed: 'delayed'
   , inactive: 'inactive'
-  , waiting: 'waiting'
   , staged: 'staged'
   , active: 'active'
   , failed: 'failed'

--- a/lib/http/routes/json.js
+++ b/lib/http/routes/json.js
@@ -41,7 +41,6 @@ function getSearch() {
 exports.stats = function(req, res){
   get(queue)
     ('delayedCount')
-    ('waitingCount')
     ('stagedCount')
     ('inactiveCount')
     ('completeCount')

--- a/lib/http/routes/json.js
+++ b/lib/http/routes/json.js
@@ -28,21 +28,25 @@ function getSearch() {
 /**
  * Get statistics including:
  * 
+ *   - delayed count
+ *   - waiting count
+ *   - staged count
  *   - inactive count
  *   - active count
  *   - complete count
  *   - failed count
- *   - delayed count
  *
  */
 
 exports.stats = function(req, res){
   get(queue)
+    ('delayedCount')
+    ('waitingCount')
+    ('stagedCount')
     ('inactiveCount')
     ('completeCount')
     ('activeCount')
     ('failedCount')
-    ('delayedCount')
     ('workTime')
     (function(err, obj){
       if (err) return res.send({ error: err.message });

--- a/lib/http/routes/json.js
+++ b/lib/http/routes/json.js
@@ -75,6 +75,12 @@ exports.jobRange = function(req, res){
     , to = parseInt(req.params.to, 10)
     , order = req.params.order;
 
+  if(order == 'desc'){
+	  var swap = from;
+	  from = -1-to;
+	  to = -1-swap;
+  }
+  
   Job.range(from, to, order, function(err, jobs){
     if (err) return res.send({ error: err.message });
     res.send(jobs);
@@ -91,6 +97,12 @@ exports.jobStateRange = function(req, res){
     , to = parseInt(req.params.to, 10)
     , order = req.params.order;
 
+  if(order == 'desc'){
+	  var swap = from;
+	  from = -1-to;
+	  to = -1-swap;
+  }
+  
   Job.rangeByState(state, from, to, order, function(err, jobs){
     if (err) return res.send({ error: err.message });
     res.send(jobs);
@@ -108,6 +120,12 @@ exports.jobTypeRange = function(req, res){
     , to = parseInt(req.params.to, 10)
     , order = req.params.order;
 
+  if(order == 'desc'){
+	  var swap = from;
+	  from = -1-to;
+	  to = -1-swap;
+  }
+  
   Job.rangeByType(type, state, from, to, order, function(err, jobs){
     if (err) return res.send({ error: err.message });
     res.send(jobs);

--- a/lib/http/routes/json.js
+++ b/lib/http/routes/json.js
@@ -167,8 +167,7 @@ exports.updateState = function(req, res){
 
   Job.get(id, function(err, job){
     if (err) return res.send({ error: err.message });
-    job.state(state);
-    job.save(function(err){
+    job.state(state, function(err) {
       if (err) return res.send({ error: err.message });
       res.send({ message: 'updated state' });
     });

--- a/lib/http/views/_job.jade
+++ b/lib/http/views/_job.jade
@@ -27,6 +27,12 @@
           tr
             td Attempts:
             td.attempts
+          tr
+            td Restarts:
+            td.restarts
+          tr
+            td Precursors:
+            td.after
           tr.time
             td Duration:
             td.duration

--- a/lib/http/views/_job.jade
+++ b/lib/http/views/_job.jade
@@ -32,6 +32,9 @@
             td.restarts
           tr
             td Precursors:
+            td.precursors
+          tr
+            td Remaining:
             td.after
           tr.time
             td Duration:

--- a/lib/http/views/_menu.jade
+++ b/lib/http/views/_menu.jade
@@ -4,10 +4,6 @@ ul#menu
     a(href='./delayed')
       .count 0
       | Delayed
-  li.waiting
-    a(href='./waiting')
-      .count 0
-      | Waiting
   li.staged
     a(href='./staged')
       .count 0

--- a/lib/http/views/_menu.jade
+++ b/lib/http/views/_menu.jade
@@ -1,5 +1,17 @@
 
 ul#menu
+  li.delayed
+    a(href='./delayed')
+      .count 0
+      | Delayed
+  li.waiting
+    a(href='./waiting')
+      .count 0
+      | Waiting
+  li.staged
+    a(href='./staged')
+      .count 0
+      | Staged
   li.inactive
     a(href='./inactive')
       .count 0
@@ -16,7 +28,3 @@ ul#menu
     a(href='./complete')
       .count 0
       | Complete
-  li.delayed
-    a(href='./delayed')
-      .count 0
-      | Delayed

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -156,6 +156,62 @@ Queue.prototype.promote = function(ms){
 };
 
 /**
+ * Restart jobs that don't update themselves within their heartbeat interval,
+ * checking every `ms`, defaulting to 5 seconds.
+ *
+ * @params {Number} ms
+ * @api public
+ */
+
+Queue.prototype.watchdog = function(ms){
+  var client = this.client
+    , ms = ms || 5000
+    , limit = 20;
+
+  setInterval(function(){
+    client.sort('q:jobs:active'
+      , 'by', 'q:job:*->update_by'
+      , 'get', '#'
+      , 'get', 'q:job:*->update_by'
+      , 'limit', 0, limit, function(err, jobs){
+      if (err || !jobs.length) return;
+
+      // iterate jobs with [id, update_by]
+      while (jobs.length) {
+        var job = jobs.slice(0, 2)
+          , id = parseInt(job[0], 10)
+          , update_by = parseInt(job[1], 10)
+          , restart = update_by < Date.now();
+
+        // if it hasn't had a heartbeat, restart the job
+
+        if (restart) {
+          Job.get(id, function(err, job){
+            if (err || !job) return;
+
+            job.restart(function(err, remaining, restarts, max){
+                if (err) return;
+            	if(remaining) {
+                    events.emit(id, 'restarted');
+                    job.inactive().log('job restarted - heartbeat missed');
+            	} else {
+            		events.emit(job.id, 'failed');
+                    job.failed().error('too many restarts');
+            	}
+              });
+
+            events.emit(id, 'restart');
+            job.inactive();
+          });
+        }
+
+        jobs = jobs.slice(2);
+      }
+    });
+  }, ms);
+};
+
+/**
  * Get setting `name` and invoke `fn(err, res)`.
  *
  * @param {String} name
@@ -323,4 +379,21 @@ Queue.prototype.activeCount = function(fn){
 
 Queue.prototype.delayedCount = function(fn){
   return this.card('delayed', fn);
+};
+
+
+/**
+ * Waiting jobs.
+ */
+
+Queue.prototype.waitingCount = function(fn){
+  return this.card('waiting', fn);
+};
+
+/**
+ * Staged jobs.
+ */
+
+Queue.prototype.stagedCount = function(fn){
+  return this.card('staged', fn);
 };

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -96,6 +96,10 @@ Queue.prototype.createJob = function(type, data){
   return new Job(type, data);
 };
 
+Queue.prototype.eventing = function(enabled) {
+    events.eventing = enabled;
+};
+
 /**
  * Proxy to auto-subscribe to events.
  *
@@ -145,7 +149,7 @@ Queue.prototype.promote = function(ms){
           Job.get(id, function(err, job){
             if (err) return;
             events.emit(id, 'promotion');
-            job.inactive();
+            job.staged();
           });
         }
 
@@ -234,10 +238,10 @@ Queue.prototype.setting = function(name, fn){
  * @api public
  */
 
-Queue.prototype.process = function(type, n, fn){
+Queue.prototype.process = function(type, n, fn, errfn){
   var self = this;
 
-  if ('function' == typeof n) fn = n, n = 1;
+  if ('function' == typeof n) errfn = fn, fn = n, n = 1;
 
   while (n--) {
     (function(worker){
@@ -248,7 +252,7 @@ Queue.prototype.process = function(type, n, fn){
       worker.on('job complete', function(job){
         self.client.incrby('q:stats:work-time', job.duration);
       });
-    })(new Worker(this, type).start(fn));
+    })(new Worker(this, type).start(fn, errfn));
   }
 };
 
@@ -379,15 +383,6 @@ Queue.prototype.activeCount = function(fn){
 
 Queue.prototype.delayedCount = function(fn){
   return this.card('delayed', fn);
-};
-
-
-/**
- * Waiting jobs.
- */
-
-Queue.prototype.waitingCount = function(fn){
-  return this.card('waiting', fn);
 };
 
 /**

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -100,6 +100,10 @@ Queue.prototype.eventing = function(enabled) {
     events.eventing = enabled;
 };
 
+Queue.prototype.indexing = function(enabled) {
+    Job.indexing = enabled;
+};
+
 /**
  * Proxy to auto-subscribe to events.
  *
@@ -243,8 +247,12 @@ Queue.prototype.process = function(type, n, fn, errfn){
 
   if ('function' == typeof n) errfn = fn, fn = n, n = 1;
 
+  if(!self.workers) self.workers = [];
+
   while (n--) {
     (function(worker){
+      self.workers.push(worker);
+
       worker.on('error', function(err){
         self.emit('error', err);
       });
@@ -255,6 +263,60 @@ Queue.prototype.process = function(type, n, fn, errfn){
     })(new Worker(this, type).start(fn, errfn));
   }
 };
+
+/**
+ * Stop all running workers.  As workers need to finish whatever
+ * they are doing, this could take some time.  The queue will emit
+ * the event 'stopped' once all workers are stopped
+ *
+ * @api public
+ */
+
+Queue.prototype.stop = function() {
+    var self = this;
+
+    if(!self.workers) return;
+
+    // Tell each worker to stop
+
+    for(var i = 0; i < self.workers.length; i++)
+        self.workers[i].stop();
+};
+
+/**
+ * Called by a worker when it stops
+ *
+ * @param {Worker} worker
+ * @api private
+ */
+
+Queue.prototype.stopped = function(worker) {
+    var self = this;
+
+    for(var i = 0; i < self.workers.length; i++)
+    {
+        if(worker == self.workers[i])
+        {
+            self.workers.splice(i, 1);
+            break;
+        }
+    }
+
+    if(!self.workers.length)
+        self.emit('stopped', true);
+};
+
+/**
+ * Returns the number of running workers
+ *
+ * @returns {Number} number of running workers
+ * @api public
+ */
+
+Queue.prototype.running = function() {
+    var self = this;
+    return self.workers.length;
+}
 
 /**
  * Get the job types present and callback `fn(err, types)`.

--- a/lib/queue/events.js
+++ b/lib/queue/events.js
@@ -33,6 +33,7 @@ exports.key = 'q:events';
  */
 
 exports.add = function(job){
+  if(!exports.eventing) return;
   if (job.id) exports.jobs[job.id] = job;
   if (!exports.subscribed) exports.subscribe();
 };
@@ -44,6 +45,7 @@ exports.add = function(job){
  */
 
 exports.subscribe = function(){
+  if(!exports.eventing) return;
   if (exports.subscribed) return;
   var client = redis.pubsubClient();
   client.subscribe(exports.key);
@@ -86,6 +88,7 @@ exports.onMessage = function(channel, msg){
  */
 
 exports.emit = function(id, event) {
+  if(!exports.eventing) return;
   var client = redis.client()
     , msg = JSON.stringify({
       id: id

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -549,23 +549,24 @@ Job.prototype.removeState = function(state, fn){
  * Set state to `state`.
  *
  * @param {String} state
+ * @param {Function} fn
  * @return {Job} for chaining
  * @api public
  */
 
-Job.prototype.state = function(state){
+Job.prototype.state = function(state, fn) {
   var self = this;
   var client = self.client;
   client.getset('q:job:' + self.id + ':state', state, function(err, old){
 	  if(err) console.log('error: stage change could not occur', err);
-	  if(err || (old == state)) return; // we're already in the state or an error occurred
+	  if(err || (old == state)) return (fn||noop)(err); // we're already in the state or an error occurred
 	  self.removeState(old);
 	  self._state = state;
 	  if ('active' == state) self.heartbeat();
 	  if (('complete' == state) || ('removed' == state)) self.release();
 
 	  if('removed' != state){
-		  self.set('state', state);
+		  self.set('state', state, fn);
 		  client.zadd('q:jobs', self._priority, self.id, noop);
 		  client.zadd('q:jobs:' + state, self._priority, self.id, noop);
 		  client.zadd('q:jobs:' + self.type + ':' + state, self._priority, self.id, noop);
@@ -582,6 +583,8 @@ Job.prototype.state = function(state){
 				 });
 		  }
 	  }
+	  else if(fn)
+		  fn();
   });
   return this;
 };

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -13,7 +13,7 @@ var EventEmitter = require('events').EventEmitter
   , events = require('./events')
   , redis = require('../redis')
   , reds = require('reds')
-  , noop = function(){};
+  , noop = function(err){ if(err) console.log('error: ignoring in noop', err); };
 
 /**
  * Expose `Job`.
@@ -267,6 +267,8 @@ Job.prototype.toJSON = function(){
     , duration: this.duration
     , delay: this._delay
     , heartbeat: this._heartbeat
+    , after: this._after
+    , precursors: this._precursors
     , attempts: {
         made: this._attempts
       , remaining: this._max_attempts - this._attempts
@@ -555,6 +557,7 @@ Job.prototype.state = function(state){
   var self = this;
   var client = self.client;
   client.getset('q:job:' + self.id + ':state', state, function(err, old){
+	  if(err) console.log('error: stage change could not occur', err);
 	  if(err || (old == state)) return; // we're already in the state or an error occurred
 	  self.removeState(old);
 	  self._state = state;
@@ -573,7 +576,10 @@ Job.prototype.state = function(state){
 			self.acquire();
 		  }
 		  if ('waiting' == state){
-			  self.attachAll(function(err){ if(!self._after) self.staged(); });
+			  self.attachAll(function(err){
+				  if(err) console.log('error: attachAll failed', err);
+				  if(!self._after) self.staged();
+				 });
 		  }
 	  }
   });
@@ -600,6 +606,7 @@ Job.prototype.attachAll = function(cb){
 	var remaining = ids.length;
 	ids.forEach(function(id){
 		self.attach(id, function(err){
+			if(err) console.log('error: attach failed', err);
 			remaining--;
 			if(!remaining){
 				client.hget('q:job:' + self.id, 'after', function(err, val){
@@ -637,13 +644,14 @@ Job.prototype.attach = function(id, cb){
 		 client.get('q:job:' + id + ':state', function(err, state){
 			 if(err) return cb(err);
 			 
-			 if(!state || (state == 'complete')) {
+			 if(!state || (state == 'complete') || (state == 'removed')) {
 				 // Verify the job has been removed
-				 client.srem('q:after:' + id, function(err, cnt){
+				 client.srem('q:after:' + id, self.id, function(err, cnt){
 					 if(err || !cnt) return cb(err);
-					 client.hincrby('q:job:' + self.id, 'after', -1, cb(err));
+					 client.hincrby('q:job:' + self.id, 'after', -1, cb);
 				 });
 			 }
+			 else cb();
 		 });
 	  });
   });
@@ -680,7 +688,10 @@ Job.prototype.release = function(){
   });	
 
   if(!self._group) return this;
-  
+
+  // Make sure the job is no longer in the staging area (if being deleted)
+  client.zrem('q:staged:' + self._group, self.id, noop);
+
   // Give lock to next job in group
   client.get('q:lockowners:' + self._group, function(err, id){
 	  if(err || (id != self.id)) return;
@@ -718,11 +729,16 @@ Job.prototype.acquire = function(){
 		// We got the lock - now give it to the candidate
 		Job.get(groups[0], function(err, job){
 		  if(err || !job){
-			  // Bad news: couldn't give them the lock for some reason: try again
-			  client.del('q:lockowners:' + self._group, function(err){
-			    if(err) return;
-				self.acquire();
+			  // Bad news: couldn't give them the lock for some reason
+			  // (they were probably deleted) - clean up and try again
+			  
+			  client.zrem('q:staged:' + self._group, groups[0], function(){
+				  client.del('q:lockowners:' + self._group, function(err){
+				    if(err) return;
+					self.acquire();
+				  });				  
 			  });
+			  
 			  return;
 		  }
 		  

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -919,13 +919,13 @@ Job.prototype.update = function(fn){
   this.set('priority', this._priority);
 
   // data
-  this.set('data', json, fn);
+  this.set('data', json);
 
   // state
   this.state(this._state);
 
   // search data
-  getSearch().index(json, this.id);
+  getSearch().index(json, this.id, fn);
   
   return this;
 };

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -13,6 +13,7 @@ var EventEmitter = require('events').EventEmitter
   , events = require('./events')
   , redis = require('../redis')
   , reds = require('reds')
+  , crypto = require('crypto')
   , noop = function(err){ if(err) console.log('error: ignoring in noop', err); };
 
 /**
@@ -118,7 +119,7 @@ exports.range = function(from, to, order, fn){
 };
 
 /**
- * Get jobs of `state`, with the range `from`..`to`
+ * Get job IDs of `state`, with the range `from`..`to`
  * and invoke callback `fn(err, ids)`.
  *
  * @param {String} state
@@ -129,9 +130,26 @@ exports.range = function(from, to, order, fn){
  * @api public
  */
 
-exports.rangeByState = function(state, from, to, order, fn){
-  redis.client().zrange('q:jobs:' + state, from, to, get(fn, order));
+exports.idRangeByState = function(state, from, to, order, fn){
+  redis.client().zrange('q:jobs:' + state, from, to, fn);
 };
+
+/**
+ * Get jobs of `state`, with the range `from`..`to`
+ * and invoke callback `fn(err, jobs)`.
+ *
+ * @param {String} state
+ * @param {Number} from
+ * @param {Number} to
+ * @param {String} order
+ * @param {Function} fn
+ * @api public
+ */
+
+exports.rangeByState = function(state, from, to, order, fn){
+    redis.client().zrange('q:jobs:' + state, from, to, get(fn, order));
+};
+
 
 /**
  * Get jobs of `type` and `state`, with the range `from`..`to`
@@ -170,8 +188,6 @@ exports.get = function(id, fn){
     // we can just merge these
     job.type = hash.type;
     job._delay = Number(hash.delay);
-    job._after = Number(hash.after);
-    job._precursors = hash.precursors;
     job._group = hash.group;
     job._heartbeat = Number(hash.heartbeat);
     job.priority(Number(hash.priority));
@@ -267,8 +283,6 @@ Job.prototype.toJSON = function(){
     , duration: this.duration
     , delay: this._delay
     , heartbeat: this._heartbeat
-    , after: this._after
-    , precursors: this._precursors
     , attempts: {
         made: this._attempts
       , remaining: this._max_attempts - this._attempts
@@ -388,22 +402,6 @@ Job.prototype.heartbeat = function(ms){
 };
 
 /**
- * Sets a job that is a precursor to this job.
- *
- * @param {Job} precursor
- * @return {Job|Number}
- * @api public
- */
-
-Job.prototype.after = function(precursor){
-  if (0 == arguments.length) return this._after;
-  this._after = this.after || 0;
-  this._precursors = this._precursors ? this._precursors+','+precursor.id : ''+precursor.id;
-  if(this._state != 'delayed') this._state = 'waiting';	  
-  return this;
-};
-
-/**
  * Sets a job as part of a staged group
  *
  * @param {Job} precursor
@@ -414,7 +412,7 @@ Job.prototype.after = function(precursor){
 Job.prototype.serialize = function(group){
   if (0 == arguments.length) return this._group;
   this._group = group;
-  if((this._state != 'delayed') && (this._state != 'waiting')) this._state = 'staged';
+  if(this._state != 'delayed') this._state = 'staged';
   return this;
 };
 
@@ -522,30 +520,67 @@ Job.prototype.attempts = function(n){
  */
 
 Job.prototype.remove = function(fn){
-  this.state('removed');
-  getSearch().remove(this.id);
-  this.client.del('q:job:' + this.id, noop);
-  this.client.del('q:job:' + this.id + ':state', noop);
-  this.client.del('q:job:' + this.id + ':log', fn || noop);
+  var self = this;
+  var client = self.client;
+
+  this.state('removed', function(err)
+  {
+      if(err) return (fn || noop)(err);
+
+      getSearch().remove(this.id);
+      client.del('q:job:' + this.id, noop);
+      client.del('q:job:' + this.id + ':state', noop);
+      client.del('q:job:' + this.id + ':log', fn || noop);
+  });
+
   return this;
 };
 
 /**
- * Remove state and callback `fn(err)`.
+ * Set state to `state`.
  *
- * @param {Function} fn
+ * @param {String} script
  * @return {Job} for chaining
- * @api public
+ * @api private
  */
 
-Job.prototype.removeState = function(state, fn){
-  if ('function' == typeof state) fn = state, state = this._state;
-  if (!state) state = this._state;
-  var client = this.client;
-  client.zrem('q:jobs', this.id, noop);
-  client.zrem('q:jobs:' + state, this.id, noop);
-  client.zrem('q:jobs:' + this.type + ':' + state, this.id, noop);
-  return this;
+var scripts = {};
+var scriptCache = {};
+
+Job.prototype.cachedEval = function(script) {
+    var args = Array.prototype.slice.call(arguments, 0);
+    var fn = args[args.length-1];
+    var hash = scriptCache[script];
+    var self = this;
+    var client = self.client;
+
+    if(typeof fn != 'function') {
+        args.push(noop);
+        fn = noop;
+    }
+
+    if(!hash) {
+      hash = crypto.createHash('sha1').update(scripts[script], 'utf8').digest('hex');
+      scriptCache[script] = hash;
+    }
+
+    args[0] = hash;
+    args[args.length-1] = function(err) {
+        if(err && (err.message.indexOf('NOSCRIPT') >= 0)) {
+            console.log("info: loading script " + script + " into cache as " + scriptCache[script]);
+
+            args[0] = scripts[script];
+            args[args.length-1] = fn;
+
+            return client.eval.apply(client, args);
+        }
+        else {
+            return fn.apply(self, arguments);
+        }
+    };
+
+    client.evalsha.apply(client, args);
+    return this;
 };
 
 /**
@@ -557,204 +592,75 @@ Job.prototype.removeState = function(state, fn){
  * @api public
  */
 
+scripts.stateLUA =
+      "local acquire = nil\n"
+    + "local stateChange = nil\n"
+    + "acquire = function(id, priority, group)\n"
+        + "if not group or group == '' then return 0 end\n"
+        + "priority = tonumber(priority)\n"
+        + "if not priority then priority = 0 end\n"
+        + "local owner = redis.call('get', 'q:lockowners:' .. group)\n"
+        + "if owner and owner ~= id then\n"
+            + "local oprio = tonumber(redis.call('hget', 'q:job:' .. owner, 'priority'))\n"
+            + "local ostate = redis.call('hget', 'q:job:' .. owner, 'state')\n"
+            + "local otype = redis.call('hget', 'q:job:' .. owner, 'type')\n"
+            + "if not oprio then oprio = 0 end\n"
+            + "if 'inactive' == ostate and otype and oprio > priority then\n"
+                + "if redis.call('zrem', 'q:jobs:' .. otype .. ':inactive', owner) == 1 then\n"
+                    + "stateChange(tostring(owner), otype, 'staged', oprio, group, nil)\n"
+                    + "return 1\n"
+                + "end\n"
+            + "end\n"
+        + "end\n"
+        + "if not owner and redis.call('zcard', 'q:staged:' .. group) ~= 0 then\n"
+            + "local best = redis.call('zrange', 'q:staged:' .. group, 0, 0)[1]\n"
+            + "redis.call('zrem', 'q:staged:' .. group, best)\n"
+            + "redis.call('set', 'q:lockowners:' .. group, best)\n"
+            + "local bprio = tonumber(redis.call('hget', 'q:job:' .. best, 'priority'))\n"
+            + "local btype = redis.call('hget', 'q:job:' .. best, 'type')\n"
+            + "stateChange(tostring(best), btype, 'inactive', bprio, group, nil)\n"
+            + "return 1\n"
+        + "end\n"
+        + "return 0\n"
+    + "end\n"
+    + "stateChange = function(id, type, state, priority, group, update_by)\n"
+        + "local old = redis.call('getset', 'q:job:' .. id .. ':state', state)\n"
+        + "if state == old then return state end\n" // state has already changed
+        + "if 'active' == state and update_by then redis.call('hset', 'q:job:' .. id, 'update_by', update_by) end\n"
+        + "if 'removed' == state then redis.call('zrem', 'q:jobs', id) end\n"
+        + "if old then\n"
+            + "redis.call('zrem', 'q:jobs:' .. old, id)\n"
+            + "redis.call('zrem', 'q:jobs:' .. type .. ':' .. old, id)\n"
+        + "end\n"
+        + "if ('complete' == state or 'removed' == state) and group then redis.call('zrem', 'q:staged:' .. group, id) end\n"
+        + "if 'removed' ~= state then\n"
+            + "redis.call('hset', 'q:job:' .. id, 'state', state)\n"
+            + "redis.call('zadd', 'q:jobs', priority, id)\n"
+            + "redis.call('zadd', 'q:jobs:' .. state, priority, id)\n"
+            + "redis.call('zadd', 'q:jobs:' .. type .. ':' .. state, priority, id)\n"
+            + "if 'inactive' == state then redis.call('lpush', 'q:' .. type .. ':jobs', 1) end\n"
+            + "if 'staged' == state and group then redis.call('zadd', 'q:staged:' .. group, priority, id) end\n"
+        + "end\n"
+        + "if group and ('complete' == state or 'removed' == state or ('staged' == state and 'inactive' == old)) then\n"
+            + "if redis.call('get', 'q:lockowners:' .. group) == id then redis.call('del', 'q:lockowners:' .. group) end\n"
+        + "end\n"
+        + "if acquire(id, priority, group) == 1 then return redis.call('hget', 'q:job:' .. id, 'state') end\n"
+        + "return state\n"
+    + "end\n"
+    + "return stateChange(ARGV[1], ARGV[2], ARGV[3], ARGV[4], ARGV[5], ARGV[6])\n"
+    ;
+
 Job.prototype.state = function(state, fn) {
   var self = this;
   var client = self.client;
-  client.getset('q:job:' + self.id + ':state', state, function(err, old){
-	  if(err) console.log('error: stage change could not occur', err);
-	  if(err || (old == state)) return (fn||noop)(err); // we're already in the state or an error occurred
-	  self.removeState(old);
-	  self._state = state;
-	  if ('active' == state) self.heartbeat();
-	  if (('complete' == state) || ('removed' == state)) self.release();
+  var update_by = this._heartbeat ? Date.now() + this._heartbeat : null;
 
-	  if('removed' != state){
-		  self.set('state', state, fn);
-		  client.zadd('q:jobs', self._priority, self.id, noop);
-		  client.zadd('q:jobs:' + state, self._priority, self.id, noop);
-		  client.zadd('q:jobs:' + self.type + ':' + state, self._priority, self.id, noop);
-		  // increase available jobs, used by Worker#getJob()
-		  if ('inactive' == state) client.lpush('q:' + self.type + ':jobs', 1);	
-		  if ('staged' == state){
-			client.zadd('q:staged:' + self._group, self._priority, self.id, noop);
-			self.acquire();
-		  }
-		  if ('waiting' == state){
-			  self.attachAll(function(err){
-				  if(err) console.log('error: attachAll failed', err);
-				  if(!self._after) self.staged();
-				 });
-		  }
-	  }
-	  else if(fn)
-		  fn();
+  self.cachedEval('stateLUA', 0, ''+self.id, self.type, state, self._priority, self._group, update_by, function(err, newstate) {
+    if(err) return (fn || noop)(err);
+    self._state = newstate;
+    if(fn) fn();
   });
-  return this;
-};
 
-
-/**
- * Attach this job to all of its precursors.  After the callback is called,
- * the _after field will have been updated with the most recent value (to
- * allow the caller to decide if the job should be moved immediately to another
- * state or not).
- *
- * @api private
- */
-
-Job.prototype.attachAll = function(cb){
-	var self = this;
-	var client = self.client;
-
-	if(!self._precursors) return;
-	
-	var ids = self._precursors.split(',');
-	var remaining = ids.length;
-	ids.forEach(function(id){
-		self.attach(id, function(err){
-			if(err) console.log('error: attach failed', err);
-			remaining--;
-			if(!remaining){
-				client.hget('q:job:' + self.id, 'after', function(err, val){
-					if(err) return cb(err);
-					self._after = val;
-					cb(err, self);
-				});
-			}
-		});
-	});
-};
-
-/**
- * Attach this job to it's precursor (given by the 'id' argument)
- *
- * @param {String} id
- * @return {Job} for chaining
- * @api private
- */
-
-Job.prototype.attach = function(id, cb){
-  var self = this;
-  var client = self.client;
-
-  // First, go ahead and add it to the dependents set for the precursor and
-  // increment the id.
-  client.sadd('q:after:' + id, self.id, function(err, cnt){
-	  if(err || !cnt) return cb(err);
-	  client.hincrby('q:job:' + self.id, 'after', 1, function(err, val){
-		 if(err) return cb(err); 
-		 
-		 // Now, to deal with a race condition where the precursor is removed
-		 // or completed while we were changing state, double check it
-		 
-		 client.get('q:job:' + id + ':state', function(err, state){
-			 if(err) return cb(err);
-			 
-			 if(!state || (state == 'complete') || (state == 'removed')) {
-				 // Verify the job has been removed
-				 client.srem('q:after:' + id, self.id, function(err, cnt){
-					 if(err || !cnt) return cb(err);
-					 client.hincrby('q:job:' + self.id, 'after', -1, cb);
-				 });
-			 }
-			 else cb();
-		 });
-	  });
-  });
-};
-
-/**
- * Release dependents and unlock others in the serialization group if this
- * job has been deleted or has successfully completed.
- *
- * @param {String} state
- * @return {Job} for chaining
- * @api private
- */
-
-Job.prototype.release = function(){
-  var self = this;
-  var client = self.client;
-
-  // Release dependents
-  client.scard('q:after:' + self.id, function(err, len) {
-	if(err || !len) return;
-	while(len--){
-	  client.spop('q:after:' + self.id, function(err, id){
-		  if(err || !id) return;
-		  client.hincrby('q:job:' + id, 'after', -1, function(err, val){
-			  if(err || val) return;
-			  Job.get(id, function(err, job){
-				if(err || !job) return;
-				job.waiting();
-			  });
-		  });
-	  });
-	}
-  });	
-
-  if(!self._group) return this;
-
-  // Make sure the job is no longer in the staging area (if being deleted)
-  client.zrem('q:staged:' + self._group, self.id, noop);
-
-  // Give lock to next job in group
-  client.get('q:lockowners:' + self._group, function(err, id){
-	  if(err || (id != self.id)) return;
-	  client.del('q:lockowners:' + self._group, function(err){
-	    if(err) return;
-	    // Give the lock to someone else (since we're not in the list, we can't get it)
-	    self.acquire();
-	  });
-  });
-  
-  return this;
-};
-
-/**
- * Attempt to acquire the lock for the best candidate in the group.
- * 
- *
- * @return {Job} for chaining
- * @api public
- */
-
-Job.prototype.acquire = function(){
-  var self = this;
-  var client = self.client;
-  if(!self._group) return this;
-  
-  // Find the best candidate
-  client.zrange('q:staged:' + self._group, 0, 0, function(err, groups){
-	if(err || (groups.length == 0)) return;
-	
-	// Try and give the candidate the lock
-	client.setnx('q:lockowners:' + self._group, groups[0], function(err, set){
-		if(err || !set) return;
-		
-		// We got the lock - now give it to the candidate
-		Job.get(groups[0], function(err, job){
-		  if(err || !job){
-			  // Bad news: couldn't give them the lock for some reason
-			  // (they were probably deleted) - clean up and try again
-			  
-			  client.zrem('q:staged:' + self._group, groups[0], function(){
-				  client.del('q:lockowners:' + self._group, function(err){
-				    if(err) return;
-					self.acquire();
-				  });				  
-			  });
-			  
-			  return;
-		  }
-		  
-		  // The job now has the lock
-		  client.zrem('q:staged:' + job._group, job.id, noop);
-		  job.inactive();
-		});
-	});
-  });
-  
   return this;
 };
 
@@ -774,7 +680,7 @@ Job.prototype.error = function(err){
     str = err;
     summary = '';
   } else {
-    str = err.stack || err.message;
+    str = err.stack || err.message || (''+err);
     summary = str.split('\n')[0];
   }
 
@@ -788,57 +694,44 @@ Job.prototype.error = function(err){
  * Set state to "complete", and progress to 100%.
  */
 
-Job.prototype.complete = function(){
+Job.prototype.complete = function(fn){
   this.set('updated_at', Date.now());
-  return this.set('progress', 100).state('complete');
+  return this.set('progress', 100).state('complete', fn);
 };
 
 /**
  * Set state to "failed".
  */
 
-Job.prototype.failed = function(){
-  return this.state('failed');
+Job.prototype.failed = function(fn){
+  return this.state('failed', fn);
 };
 
 /**
  * Set state to "inactive".
  */
 
-Job.prototype.inactive = function(){
-  return this.state('inactive');
+Job.prototype.inactive = function(fn){
+  return this.state('inactive', fn);
 };
 
 /**
  * Set state to "active".
  */
 
-Job.prototype.active = function(){
-  return this.state('active');
-};
-
-/**
- * Set state to "waiting" if this job has any dependents
- * left to fire.
- */
-
-Job.prototype.waiting = function(){
-  if(!this._after)
-	  return this.staged();
-  else{
-	  return this.state('waiting');
-  }
+Job.prototype.active = function(fn){
+  return this.state('active', fn);
 };
 
 /**
  * Set state to "staged" if this jobs of this group should be staged.
  */
 
-Job.prototype.staged = function(){
+Job.prototype.staged = function(fn){
 	  if(!this._group)
-		  return this.inactive();
+		  return this.inactive(fn);
 	  else{
-		  return this.state('staged');
+		  return this.state('staged', fn);
 	  }
 };
 
@@ -854,8 +747,6 @@ Job.prototype.save = function(fn){
   var client = this.client
     , max = this._max_attempts
     , maxr = this._max_restarts
-    , pre = this._precursors
-    , after = this._after
     , group = this._group
     , self = this;
   fn = fn || noop;
@@ -871,8 +762,6 @@ Job.prototype.save = function(fn){
     self._state = self._state || 'inactive';
     if (max) client.hset(key, 'max_attempts', max);
     if (maxr) client.hset(key, 'max_restarts', maxr);
-    if (pre) client.hset(key, 'precursors', pre);
-    if (after) client.hset(key, 'after', after);
     if (group) client.hset(key, 'group', group);
     client.sadd('q:job:types', self.type);
     self.set('type', self.type);
@@ -922,10 +811,13 @@ Job.prototype.update = function(fn){
   this.set('data', json);
 
   // state
-  this.state(this._state);
+  this.state(this._state, function(err)
+  {
+      if(err) return (fn || noop)(err);
 
-  // search data
-  getSearch().index(json, this.id, fn);
-  
+      // search data
+      getSearch().index(json, this.id, fn);
+  });
+
   return this;
 };

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -26,6 +26,8 @@ exports = module.exports = Job;
  * Search instance.
  */
 
+exports.indexing = false; // Indexing is off by default (it leaks keys in kue currently)
+
 var search;
 function getSearch() {
   if (search) return search;
@@ -527,10 +529,12 @@ Job.prototype.remove = function(fn){
   {
       if(err) return (fn || noop)(err);
 
-      getSearch().remove(this.id);
-      client.del('q:job:' + this.id, noop);
-      client.del('q:job:' + this.id + ':state', noop);
-      client.del('q:job:' + this.id + ':log', fn || noop);
+      if(exports.indexing)
+          getSearch().remove(self.id);
+
+      client.del('q:job:' + self.id, noop);
+      client.del('q:job:' + self.id + ':state', noop);
+      client.del('q:job:' + self.id + ':log', fn || noop);
   });
 
   return this;
@@ -816,8 +820,33 @@ Job.prototype.update = function(fn){
       if(err) return (fn || noop)(err);
 
       // search data
-      getSearch().index(json, this.id, fn);
+      if(exports.indexing)
+          getSearch().index(json, this.id, fn);
+      else if(fn)
+        fn();
   });
 
   return this;
+};
+
+/**
+ * Update the job and callback `fn(err)`.
+ *
+ * @param {Function} fn
+ * @api public
+ */
+
+Job.prototype.saveData = function(fn){
+    var json;
+
+    // serialize json data
+    try {
+        json = JSON.stringify(this.data);
+    } catch (err) {
+        return fn(err);
+    }
+
+    // data
+    this.set('data', json, fn);
+    return this;
 };

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -62,6 +62,30 @@ function map(jobs, ids){
 }
 
 /**
+ * Fetch the jobs for each of the given ids
+ *
+ * @param {Array} ids
+ * @param {String} order		asc or desc
+ * @param {Function} fn
+ * @api private
+ */
+
+function jobsForIds(ids, order, fn) {
+	var pending = ids.length
+	  , jobs = {};
+	if (!pending) return fn(null, ids);
+	ids.forEach(function(id){
+	  exports.get(id, function(err, job){
+	    if (err || !job) return fn(err);
+	    jobs[job.id] = job;
+	    --pending || fn(null, 'desc' == order
+	      ? map(jobs, ids).reverse()
+	      : map(jobs, ids));
+	  });
+	});
+}
+
+/**
  * Return a function that handles fetching
  * of jobs by the ids fetched.
  *
@@ -74,19 +98,8 @@ function map(jobs, ids){
 function get(fn, order) {
   return function(err, ids){
     if (err) return fn(err);
-    var pending = ids.length
-      , jobs = {};
-    if (!pending) return fn(null, ids);
-    ids.forEach(function(id){
-      exports.get(id, function(err, job){
-        if (err) return fn(err);
-        jobs[job.id] = job;
-        --pending || fn(null, 'desc' == order
-          ? map(jobs, ids).reverse()
-          : map(jobs, ids));
-      });
-    });
-  }
+    jobsForIds(ids, order, fn);
+  };
 }
 
 /**
@@ -156,17 +169,23 @@ exports.get = function(id, fn){
     // TODO: really lame, change some methods so 
     // we can just merge these
     job.type = hash.type;
-    job._delay = hash.delay;
+    job._delay = Number(hash.delay);
+    job._after = Number(hash.after);
+    job._precursors = hash.precursors;
+    job._group = hash.group;
+    job._heartbeat = Number(hash.heartbeat);
     job.priority(Number(hash.priority));
     job._progress = hash.progress;
-    job._attempts = hash.attempts;
-    job._max_attempts = hash.max_attempts;
+    job._attempts = Number(hash.attempts);
+    job._restarts = Number(hash.restarts);
+    job._max_attempts = Number(hash.max_attempts);
+    job._max_restarts = Number(hash.max_restarts);
     job._state = hash.state;
     job._error = hash.error;
-    job.created_at = hash.created_at;
-    job.updated_at = hash.updated_at;
-    job.failed_at = hash.failed_at;
-    job.duration = hash.duration;
+    job.created_at = Number(hash.created_at);
+    job.updated_at = Number(hash.updated_at);
+    job.failed_at = Number(hash.failed_at);
+    job.duration = Number(hash.duration);
     try {
       if (hash.data) job.data = JSON.parse(hash.data);
       fn(err, job);
@@ -247,11 +266,17 @@ Job.prototype.toJSON = function(){
     , failed_at: this.failed_at
     , duration: this.duration
     , delay: this._delay
+    , heartbeat: this._heartbeat
     , attempts: {
         made: this._attempts
       , remaining: this._max_attempts - this._attempts
       , max: this._max_attempts
     }
+  	, restarts: {
+      made: this._restarts
+      , remaining: this._max_restarts - this._restarts
+      , max: this._max_restarts
+  }
   };
 };
 
@@ -339,6 +364,57 @@ Job.prototype.delay = function(ms){
 };
 
 /**
+ * Set the job heartbeat to be required every `ms`.
+ * 
+ * If called with no arguments, this will trigger the heartbeat of
+ * the job so that it won't get restarted.
+ *
+ * @param {Number} ms
+ * @return {Job|Number}
+ * @api public
+ */
+
+Job.prototype.heartbeat = function(ms){
+  if (0 == arguments.length){
+	  this.set('update_by', Date.now() + this._heartbeat);
+	  return this._heartbeat;
+  }
+  this._heartbeat = ms;
+  return this;
+};
+
+/**
+ * Sets a job that is a precursor to this job.
+ *
+ * @param {Job} precursor
+ * @return {Job|Number}
+ * @api public
+ */
+
+Job.prototype.after = function(precursor){
+  if (0 == arguments.length) return this._after;
+  this._after = this.after || 0;
+  this._precursors = this._precursors ? this._precursors+','+precursor.id : ''+precursor.id;
+  if(this._state != 'delayed') this._state = 'waiting';	  
+  return this;
+};
+
+/**
+ * Sets a job as part of a staged group
+ *
+ * @param {Job} precursor
+ * @return {Job|String}
+ * @api public
+ */
+
+Job.prototype.serialize = function(group){
+  if (0 == arguments.length) return this._group;
+  this._group = group;
+  if((this._state != 'delayed') && (this._state != 'waiting')) this._state = 'staged';
+  return this;
+};
+
+/**
  * Set or get the priority `level`, which is one
  * of "low", "normal", "medium", and "high", or
  * a number in the range of -10..10.
@@ -353,6 +429,31 @@ Job.prototype.priority = function(level){
   this._priority = null == priorities[level]
     ? level
     : priorities[level];
+  return this;
+};
+
+/**
+ * Increment restarts, invoking callback `fn(remaining, restarts, max)`.
+ *
+ * @param {Function} fn
+ * @return {Job} for chaining
+ * @api public
+ */
+
+Job.prototype.restart = function(fn) {
+  var self = this
+    , client = this.client
+    , id = this.id
+    , key = 'q:job:' + id;
+
+  client.hsetnx(key, 'max_restarts', 1, function(){
+    client.hget(key, 'max_restarts', function(err, max){
+      client.hincrby(key, 'restarts', 1, function(err, restarts){
+        fn(err, Math.max(0, Number(max) + 1 - restarts), restarts, max);
+      });
+    });
+  });
+
   return this;
 };
 
@@ -382,6 +483,20 @@ Job.prototype.attempt = function(fn){
 };
 
 /**
+ * Set max restarts to `n`.
+ *
+ * @param {Number} n
+ * @return {Job} for chaining
+ * @api public
+ */
+
+Job.prototype.restarts = function(n){
+  this._max_restarts = n;
+  return this;
+};
+
+
+/**
  * Set max attempts to `n`.
  *
  * @param {Number} n
@@ -403,9 +518,10 @@ Job.prototype.attempts = function(n){
  */
 
 Job.prototype.remove = function(fn){
-  this.removeState();
+  this.state('removed');
   getSearch().remove(this.id);
-  this.client.del('q:job:' + this.id, fn || noop);
+  this.client.del('q:job:' + this.id, noop);
+  this.client.del('q:job:' + this.id + ':state', fn || noop);
   return this;
 };
 
@@ -417,12 +533,13 @@ Job.prototype.remove = function(fn){
  * @api public
  */
 
-Job.prototype.removeState = function(fn){
-  var client = this.client
-    , state = this._state;
-  client.zrem('q:jobs', this.id);
-  client.zrem('q:jobs:' + state, this.id);
-  client.zrem('q:jobs:' + this.type + ':' + state, this.id);
+Job.prototype.removeState = function(state, fn){
+  if ('function' == typeof state) fn = state, state = this._state;
+  if (!state) state = this._state;
+  var client = this.client;
+  client.zrem('q:jobs', this.id, noop);
+  client.zrem('q:jobs:' + state, this.id, noop);
+  client.zrem('q:jobs:' + this.type + ':' + state, this.id, noop);
   return this;
 };
 
@@ -435,15 +552,187 @@ Job.prototype.removeState = function(fn){
  */
 
 Job.prototype.state = function(state){
-  var client = this.client;
-  this.removeState();
-  this._state = state;
-  this.set('state', state);
-  client.zadd('q:jobs', this._priority, this.id);
-  client.zadd('q:jobs:' + state, this._priority, this.id);
-  client.zadd('q:jobs:' + this.type + ':' + state, this._priority, this.id);
-  // increase available jobs, used by Worker#getJob()
-  if ('inactive' == state) client.lpush('q:' + this.type + ':jobs', 1);
+  var self = this;
+  var client = self.client;
+  client.getset('q:job:' + self.id + ':state', state, function(err, old){
+	  if(err || (old == state)) return; // we're already in the state or an error occurred
+	  self.removeState(old);
+	  self._state = state;
+	  if ('active' == state) self.heartbeat();
+	  if (('complete' == state) || ('removed' == state)) self.release();
+
+	  if('removed' != state){
+		  self.set('state', state);
+		  client.zadd('q:jobs', self._priority, self.id, noop);
+		  client.zadd('q:jobs:' + state, self._priority, self.id, noop);
+		  client.zadd('q:jobs:' + self.type + ':' + state, self._priority, self.id, noop);
+		  // increase available jobs, used by Worker#getJob()
+		  if ('inactive' == state) client.lpush('q:' + self.type + ':jobs', 1);	
+		  if ('staged' == state){
+			client.zadd('q:staged:' + self._group, self._priority, self.id, noop);
+			self.acquire();
+		  }
+		  if ('waiting' == state){
+			  self.attachAll(function(err){ if(!self._after) self.staged(); });
+		  }
+	  }
+  });
+  return this;
+};
+
+
+/**
+ * Attach this job to all of its precursors.  After the callback is called,
+ * the _after field will have been updated with the most recent value (to
+ * allow the caller to decide if the job should be moved immediately to another
+ * state or not).
+ *
+ * @api private
+ */
+
+Job.prototype.attachAll = function(cb){
+	var self = this;
+	var client = self.client;
+
+	if(!self._precursors) return;
+	
+	var ids = self._precursors.split(',');
+	var remaining = ids.length;
+	ids.forEach(function(id){
+		self.attach(id, function(err){
+			remaining--;
+			if(!remaining){
+				client.hget('q:job:' + self.id, 'after', function(err, val){
+					if(err) return cb(err);
+					self._after = val;
+					cb(err, self);
+				});
+			}
+		});
+	});
+};
+
+/**
+ * Attach this job to it's precursor (given by the 'id' argument)
+ *
+ * @param {String} id
+ * @return {Job} for chaining
+ * @api private
+ */
+
+Job.prototype.attach = function(id, cb){
+  var self = this;
+  var client = self.client;
+
+  // First, go ahead and add it to the dependents set for the precursor and
+  // increment the id.
+  client.sadd('q:after:' + id, self.id, function(err, cnt){
+	  if(err || !cnt) return cb(err);
+	  client.hincrby('q:job:' + self.id, 'after', 1, function(err, val){
+		 if(err) return cb(err); 
+		 
+		 // Now, to deal with a race condition where the precursor is removed
+		 // or completed while we were changing state, double check it
+		 
+		 client.get('q:job:' + id + ':state', function(err, state){
+			 if(err) return cb(err);
+			 
+			 if(!state || (state == 'complete')) {
+				 // Verify the job has been removed
+				 client.srem('q:after:' + id, function(err, cnt){
+					 if(err || !cnt) return cb(err);
+					 client.hincrby('q:job:' + self.id, 'after', -1, cb(err));
+				 });
+			 }
+		 });
+	  });
+  });
+};
+
+/**
+ * Release dependents and unlock others in the serialization group if this
+ * job has been deleted or has successfully completed.
+ *
+ * @param {String} state
+ * @return {Job} for chaining
+ * @api private
+ */
+
+Job.prototype.release = function(){
+  var self = this;
+  var client = self.client;
+
+  // Release dependents
+  client.scard('q:after:' + self.id, function(err, len) {
+	if(err || !len) return;
+	while(len--){
+	  client.spop('q:after:' + self.id, function(err, id){
+		  if(err || !id) return;
+		  client.hincrby('q:job:' + id, 'after', -1, function(err, val){
+			  if(err || val) return;
+			  Job.get(id, function(err, job){
+				if(err || !job) return;
+				job.waiting();
+			  });
+		  });
+	  });
+	}
+  });	
+
+  if(!self._group) return this;
+  
+  // Give lock to next job in group
+  client.get('q:lockowners:' + self._group, function(err, id){
+	  if(err || (id != self.id)) return;
+	  client.del('q:lockowners:' + self._group, function(err){
+	    if(err) return;
+	    // Give the lock to someone else (since we're not in the list, we can't get it)
+	    self.acquire();
+	  });
+  });
+  
+  return this;
+};
+
+/**
+ * Attempt to acquire the lock for the best candidate in the group.
+ * 
+ *
+ * @return {Job} for chaining
+ * @api public
+ */
+
+Job.prototype.acquire = function(){
+  var self = this;
+  var client = self.client;
+  if(!self._group) return this;
+  
+  // Find the best candidate
+  client.zrange('q:staged:' + self._group, 0, 0, function(err, groups){
+	if(err || (groups.length == 0)) return;
+	
+	// Try and give the candidate the lock
+	client.setnx('q:lockowners:' + self._group, groups[0], function(err, set){
+		if(err || !set) return;
+		
+		// We got the lock - now give it to the candidate
+		Job.get(groups[0], function(err, job){
+		  if(err || !job){
+			  // Bad news: couldn't give them the lock for some reason: try again
+			  client.del('q:lockowners:' + self._group, function(err){
+			    if(err) return;
+				self.acquire();
+			  });
+			  return;
+		  }
+		  
+		  // The job now has the lock
+		  client.zrem('q:staged:' + job._group, job.id, noop);
+		  job.inactive();
+		});
+	});
+  });
+  
   return this;
 };
 
@@ -457,13 +746,14 @@ Job.prototype.state = function(state){
 
 Job.prototype.error = function(err){
   if (0 == arguments.length) return this._error;
-
+  var str, summary;
+  
   if ('string' == typeof err) {
-    var str = err
-      , summary = '';
+    str = err;
+    summary = '';
   } else {
-    var str = err.stack || err.message
-      , summary = str.split('\n')[0];
+    str = err.stack || err.message;
+    summary = str.split('\n')[0];
   }
 
   this.set('failed_at', Date.now());
@@ -505,6 +795,31 @@ Job.prototype.active = function(){
 };
 
 /**
+ * Set state to "waiting" if this job has any dependents
+ * left to fire.
+ */
+
+Job.prototype.waiting = function(){
+  if(!this._after)
+	  return this.staged();
+  else{
+	  return this.state('waiting');
+  }
+};
+
+/**
+ * Set state to "staged" if this jobs of this group should be staged.
+ */
+
+Job.prototype.staged = function(){
+	  if(!this._group)
+		  return this.inactive();
+	  else{
+		  return this.state('staged');
+	  }
+};
+
+/**
  * Save the job, optionally invoking the callback `fn(err)`.
  *
  * @param {Function} fn
@@ -514,10 +829,14 @@ Job.prototype.active = function(){
 
 Job.prototype.save = function(fn){
   var client = this.client
-    , fn = fn || noop
     , max = this._max_attempts
+    , maxr = this._max_restarts
+    , pre = this._precursors
+    , after = this._after
+    , group = this._group
     , self = this;
-
+  fn = fn || noop;
+  
   // update
   if (this.id) return this.update(fn);
 
@@ -528,6 +847,10 @@ Job.prototype.save = function(fn){
     self.id = id;
     self._state = self._state || 'inactive';
     if (max) client.hset(key, 'max_attempts', max);
+    if (maxr) client.hset(key, 'max_restarts', maxr);
+    if (pre) client.hset(key, 'precursors', pre);
+    if (after) client.hset(key, 'after', after);
+    if (group) client.hset(key, 'group', group);
     client.sadd('q:job:types', self.type);
     self.set('type', self.type);
     self.set('created_at', Date.now());
@@ -559,6 +882,12 @@ Job.prototype.update = function(fn){
 
   // delay
   if (this._delay) this.set('delay', this._delay);
+  
+  // Heartbeat
+  if (this._heartbeat) {
+	  this.set('heartbeat', this._heartbeat);
+	  this.set('update_by', Date.now() + this._heartbeat);
+  }
 
   // updated timestamp
   this.set('updated_at', Date.now());
@@ -574,4 +903,6 @@ Job.prototype.update = function(fn){
 
   // search data
   getSearch().index(json, this.id);
+  
+  return this;
 };

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -377,8 +377,10 @@ Job.prototype.delay = function(ms){
  */
 
 Job.prototype.heartbeat = function(ms){
-  if (0 == arguments.length){
-	  this.set('update_by', Date.now() + this._heartbeat);
+  if (0 == arguments.length) {
+	  if(this._heartbeat) {
+		  this.set('update_by', Date.now() + this._heartbeat);
+	  }
 	  return this._heartbeat;
   }
   this._heartbeat = ms;
@@ -523,7 +525,8 @@ Job.prototype.remove = function(fn){
   this.state('removed');
   getSearch().remove(this.id);
   this.client.del('q:job:' + this.id, noop);
-  this.client.del('q:job:' + this.id + ':state', fn || noop);
+  this.client.del('q:job:' + this.id + ':state', noop);
+  this.client.del('q:job:' + this.id + ':log', fn || noop);
   return this;
 };
 
@@ -786,6 +789,7 @@ Job.prototype.error = function(err){
  */
 
 Job.prototype.complete = function(){
+  this.set('updated_at', Date.now());
   return this.set('progress', 100).state('complete');
 };
 

--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -57,14 +57,44 @@ Worker.prototype.__proto__ = EventEmitter.prototype;
  * @api private
  */
 
-Worker.prototype.start = function(fn){
+Worker.prototype.start = function(delay, fn, errfn){
   var self = this;
-  self.getJob(function(err, job){
-    if (err) self.error(err, job);
-    if (!job || err) return process.nextTick(function(){ self.start(fn); });
-    self.process(job, fn);
-  });
+
+  if(typeof delay == 'function') errfn = fn, fn = delay, delay = false;
+
+  if(errfn) self.errfn = errfn;
+  if(!self.errfn) self.errfn = Worker.errorCallback;
+
+  var amount = 0;
+
+  if(delay)
+      amount = Math.round(Math.random()*30000);
+  else
+      amount = Math.round(Math.random()*2000);
+
+  setTimeout(function()
+  {
+      self.getJob(function(err, job){
+          if (err) self.error(err, job);
+          if (!job || err) return process.nextTick(function(){ self.start(true, fn); });
+          self.process(job, fn);
+      });
+  }, amount);
+
   return this;
+};
+
+/**
+ * Default error handler callback.
+ *
+ * @param {String} level        error level (debug, info, warning, error)
+ * @param {String} message      error message
+ * @param {Object} data         map of additional fields to include in messages. if job is known should include 'job'
+ * @api private
+ */
+
+Worker.errorCallback = function(level, message, data) {
+    console.log(level + ": " + message + " - " + JSON.stringify(data));
 };
 
 /**
@@ -76,9 +106,16 @@ Worker.prototype.start = function(fn){
  * @api private
  */
 
-Worker.prototype.error = function(err, job){
-  // TODO: emit non "error"
-  console.error(err.stack || err.message);
+Worker.prototype.error = function(err, job) {
+  var self = this;
+  self.errfn("warning", "Worker failure", {
+      job: job ? job.id : undefined,
+      type: self.type,
+      data: job ? job.data : undefined,
+      error: typeof err == 'object' ? err.message : err,
+      stack: err.stack
+  });
+
   return this;
 };
 
@@ -96,14 +133,32 @@ Worker.prototype.error = function(err, job){
 Worker.prototype.failed = function(job, err, fn){
   var self = this;
   events.emit(job.id, 'failed');
-  job.failed().error(err);
-  self.error(err, job);
-  job.attempt(function(error, remaining, attempts, max){
-    if (error) return self.error(error, job);
-    remaining
-      ? job.inactive()
-      : job.failed();
-    self.start(fn);
+
+  job.failed(function(err2) {
+      if(err2) {
+          self.errfn("error", "Worker.failed can't move job to failed", { job: job.id, type: self.type });
+      }
+
+      job.error(err);
+      self.error(err, job);
+
+      job.attempt(function(error, remaining, attempts, max){
+          if (error)
+          {
+              self.error(error, job);
+              return self.start(true, fn);
+          }
+
+          var state = remaining ? 'inactive' : 'failed';
+
+          job[state](function(err3) {
+            if(err3) {
+                self.errfn("error", "Worker.failed can't move job to " + state, { job: job.id, type: self.type });
+            }
+
+            self.start(fn);
+          });
+      });
   });
 };
 
@@ -122,15 +177,29 @@ Worker.prototype.failed = function(job, err, fn){
 Worker.prototype.process = function(job, fn){
   var self = this
     , start = new Date;
-  job.active();
-  fn(job, function(err){
-    if (err) return self.failed(job, err, fn);
-    job.complete();
-    job.set('duration', job.duration = new Date - start);
-    self.emit('job complete', job);
-    events.emit(job.id, 'complete');
-    self.start(fn);
+
+  job.active(function(err) {
+      if(err) {
+          self.errfn("error", "Worker.process can't move job to active", { job: job.id, type: self.type });
+          return self.failed(job, err, fn);
+      }
+
+      fn(job, function(err){
+          if (err) return self.failed(job, err, fn);
+
+          job.complete(function(err) {
+              if(err) {
+                  self.errfn("error", "Worker.process can't move job to complete", { job: job.id, type: self.type });
+              }
+
+              job.set('duration', job.duration = new Date - start);
+              self.emit('job complete', job);
+              events.emit(job.id, 'complete');
+              self.start(fn);
+          });
+      });
   });
+
   return this;
 };
 
@@ -170,10 +239,74 @@ Worker.prototype.getJob = function(fn){
 
   // BLPOP indicates we have a new inactive job to process
   client.blpop('q:' + self.type + ':jobs', 0, function(err) {
-    self.zpop('q:jobs:' + self.type + ':inactive', function(err, id){
-      if (err) return fn(err);
+    if(err) {
+      self.errfn("warning", "Worker.getJob waiting for job failed", { error: err.message, type: self.type });
+
+        // Attempt to revert the blpop
+        // (after a short pause in case redis had a hiccup)
+
+      setTimeout(function() {
+        client.lpush('q:' + self.type + ':jobs', 1, function(err2) {
+          if(err2) self.errfn("error", "Worker.getJob could not retry blpop", { error: err2.message, type: self.type });
+        });
+      }, 2500);
+
+      return fn(err);
+    }
+
+    self.zpop('q:jobs:' + self.type + ':inactive', function(err, id) {
+      if (err) {
+          self.errfn("warning", "Worker.getJob can't pop job", { error: err.message });
+
+          // Attempt to revert the blpop
+          // (after a short pause in case redis had a hiccup)
+
+          setTimeout(function() {
+              client.lpush('q:' + self.type + ':jobs', 1, function(err2) {
+                  if(err2) self.errfn("error", "Worker.getJob could not revert blpop", { error: err2.message, type: self.type });
+              });
+          }, 2500);
+
+          return fn(err); // return the outer error
+      }
+
       if (!id) return fn();
-      Job.get(id, fn);
+
+      Job.get(id, function(err, job) {
+          if(err || !job) {
+              self.errfn("warning", "Worker.getJob can't find next job", { job: id, error: err ? err.message : undefined, type: self.type });
+
+              // Attempt to put the job back on the queue if it still exists
+              // (after a short pause in case redis had a hiccup)
+
+              setTimeout(function() {
+                  var lua =
+                        "local state = redis.call('hget', KEYS[1], 'state')\n"
+                      + "local jtype = redis.call('hget', KEYS[1], 'type')\n"
+                      + "if not state or not jtype or 'inactive' ~= state then return 0 end\n"
+                      + "local priority = redis.call('hget', KEYS[1], 'priority')\n"
+                      + "if not priority then priority = 0 end\n"
+                      + "redis.call('zadd', KEYS[2], tonumber(priority), ARGV[1])\n"
+                      + "redis.call('lpush', KEYS[3], 1)\n"
+                      + "return 1"
+                      ;
+
+                  var jkey = 'q:job:' + id;
+                  var qkey = 'q:jobs:' + self.type + ':inactive';
+                  var bkey = 'q:' + self.type + ':jobs';
+
+                  self.client.eval(lua, 3, jkey, qkey, bkey, id, function(err3, result) {
+                      if(err3 || !result) {
+                          self.errfn("error", "Worker.getJob can't add job back to kue", { job: id, error: err3 ? err3.message : undefined, result: result, type: self.type });
+                      } else {
+                          self.errfn("info", "Worker.getJob added job back to kue", { job: id, type: self.type });
+                      }
+                  });
+              }, 2500);
+          }
+
+          return fn(err, job);
+      });
     });
   });
 };

--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -70,18 +70,49 @@ Worker.prototype.start = function(delay, fn, errfn){
   if(delay)
       amount = Math.round(Math.random()*30000);
   else
-      amount = Math.round(Math.random()*2000);
+      amount = Math.round(Math.random()*200);
+
+  if(self.stopped) {
+      self.queue.stopped(self);
+      return self;
+  }
 
   setTimeout(function()
   {
-      self.getJob(function(err, job){
+      self.getJob(function(err, job, timeout){
           if (err) self.error(err, job);
-          if (!job || err) return process.nextTick(function(){ self.start(true, fn); });
+
+          if(timeout)
+              return process.nextTick(function(){ self.start(false, fn); });
+
+          if (!job || err)
+              return process.nextTick(function(){ self.start(true, fn); });
+
           self.process(job, fn);
       });
   }, amount);
 
   return this;
+};
+
+/**
+ * Tell the worker to stop processing jobs.
+ *
+ * @api private
+ */
+
+Worker.prototype.stop = function() {
+    var self = this;
+
+    self.stopped = true;
+
+    // Push a few entries on the queue to trigger blpop to timeout
+    // Why delay and trigger more than one?  Someone else might scoop up
+    // the event before realizing they are being restarted - so then they
+    // have a long delay before they end up restarting.
+
+    setTimeout(function() { self.client.lpush('q:' + self.type + ':jobs', -1, function() {}); }, 2000);
+    setTimeout(function() { self.client.lpush('q:' + self.type + ':jobs', -1, function() {}); }, 2000);
 };
 
 /**
@@ -238,7 +269,11 @@ Worker.prototype.getJob = function(fn){
     || (clients[self.type] = redis.createClient());
 
   // BLPOP indicates we have a new inactive job to process
-  client.blpop('q:' + self.type + ':jobs', 0, function(err) {
+
+  var timeout = 45 + Math.round(Math.random()*15);
+
+  client.blpop('q:' + self.type + ':jobs', timeout, function(err, data) {
+
     if(err) {
       self.errfn("warning", "Worker.getJob waiting for job failed", { error: err.message, type: self.type });
 
@@ -254,7 +289,20 @@ Worker.prototype.getJob = function(fn){
       return fn(err);
     }
 
-    self.zpop('q:jobs:' + self.type + ':inactive', function(err, id) {
+    if(!data)
+    {
+        // We timed out so that the worker can check if it should stop
+        return fn(null, null, true);
+    }
+
+    if((data.length == 2) && (data[1] == -1))
+    {
+        // We received a notification that this is a shutdown
+        // If we're not really shutting down we'll ignore this quickly
+        return fn(null, null, true);
+    }
+
+      self.zpop('q:jobs:' + self.type + ':inactive', function(err, id) {
       if (err) {
           self.errfn("warning", "Worker.getJob can't pop job", { error: err.message });
 


### PR DESCRIPTION
Hi, I've created a bunch of QoS extensions to Kue this would be useful to incorporate into the master if you're interested.  There are three main extensions that I added:

+ watchdog+heartbeat to auto-restart stuck/dead jobs (useful if, for example, a server that's processing jobs reboots without a graceful shutdown).
+ dependencies to allow jobs to wait for other jobs to complete before starting to give more granular controls of execution ordering even with a large pool of available workers (dependencies even work across different job types).
+ serialized execution to ensure that only one of a related group of jobs can execute at the same time (so, for example, you could use this to ensure that no two jobs related to the same user run at the same time across all workers).  As with dependencies, this works across different job types.
