### PR TITLE
/job/search hangs

### DIFF
--- a/lib/http/routes/json.js
+++ b/lib/http/routes/json.js
@@ -27,7 +27,7 @@ function getSearch() {
 
 /**
  * Get statistics including:
- * 
+ *
  *   - inactive count
  *   - active count
  *   - complete count
@@ -176,7 +176,7 @@ exports.updateState = function(req, res){
  */
 
 exports.search = function(req, res){
-  getSearch().query(req.query.q, function(err, ids){
+  getSearch().query(req.query.q).end(function(err, ids){
     if (err) return res.send({ error: err.message });
     res.send(ids);
   });


### PR DESCRIPTION
The job search call did not invoke query.end() so never returned.
