### PR TITLE
Singleton queue

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -63,7 +63,7 @@ exports.redis = redis;
  */
 
 exports.createQueue = function(){
-  return Queue.singleton = new Queue;
+  return Queue.singleton || (Queue.singleton = new Queue);
 };
 
 /**


### PR DESCRIPTION
Use singleton for Queue, to prevent creating a lot of redis connections on nested tasks (task processor creates a new task)
