### PR TITLE
Job get

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -316,8 +316,8 @@ Job.prototype.set = function(key, val, fn){
  */
 
 Job.prototype.get = function(key, fn){
-    this.client.hget('q:job:' + this.id, key, fn || noop);
-    return this;
+  this.client.hget('q:job:' + this.id, key, fn || noop);
+  return this;
 };
 
 /**


### PR DESCRIPTION
Add method to get job 'keys' (i.e. the opposite to Job.prototype.set())
