### PR TITLE
Allow job to be subscribed for event mapping

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -548,7 +548,7 @@ Job.prototype.save = function(fn){
     self.update(fn);
 
     // add the job for event mapping
-    events.add(self);
+    self.subscribe();
   });
 
   return this;
@@ -588,4 +588,16 @@ Job.prototype.update = function(fn){
 
   // search data
   getSearch().index(json, this.id);
+};
+
+/**
+ * Subscribe this job for event mapping.
+ *
+ * @return {Job} for chaining
+ * @api public
+ */
+
+Job.prototype.subscribe = function(){
+  events.add(this);
+  return this;
 };


### PR DESCRIPTION
This addresses the issue that @RandomEtc raised in #91.  It allows one to call `subscribe` on any job instance to subscribe it to events.
