### PR TITLE
Removing redis log keys when job is removed

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -420,6 +420,7 @@ Job.prototype.attempts = function(n){
 Job.prototype.remove = function(fn){
   this.removeState();
   getSearch().remove(this.id);
+  this.client.del('q:job:' + this.id + ':log', noop);
   this.client.del('q:job:' + this.id, fn || noop);
   return this;
 };


### PR DESCRIPTION
Shamelessly stolen from @bbn, all credit to him!
Fixes: #97
