### PR TITLE
Pull request for patch for Issue 187.

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -288,6 +288,7 @@ Job.prototype.log = function(str){
   });
 
   this.client.rpush('q:job:' + this.id + ':log', str);
+  this.set('updated_at', Date.now());
   return this;
 };
 
@@ -334,6 +335,7 @@ Job.prototype.progress = function(complete, total){
   if (0 == arguments.length) return this._progress;
   var n = Math.min(100, complete / total * 100 | 0);
   this.set('progress', n);
+  this.set('updated_at', Date.now());
   events.emit(this.id, 'progress', n);
   return this;
 };
@@ -388,6 +390,7 @@ Job.prototype.attempt = function(fn){
   client.hsetnx(key, 'max_attempts', 1, function(){
     client.hget(key, 'max_attempts', function(err, max){
       client.hincrby(key, 'attempts', 1, function(err, attempts){
+        self.set('updated_at', Date.now());
         fn(err, Math.max(0, max - attempts), attempts, max);
       });
     });
@@ -460,6 +463,7 @@ Job.prototype.state = function(state){
   client.zadd('q:jobs:' + this.type + ':' + state, this._priority, this.id);
   // increase available jobs, used by Worker#getJob()
   if ('inactive' == state) client.lpush('q:' + this.type + ':jobs', 1);
+  this.set('updated_at', Date.now());
   return this;
 };
 


### PR DESCRIPTION
This patch modifies the following methods so that they update the updated_at timestamp:
- The Job.log method
- The Job.progress method
- The Job.attempt method
- The Job.state method

Consequently, the following methods will also exhibit the same behaviour:
- The Job.error method, because it uses the log method.
- The complete, failed, inactive, active, methods, because they use state method.

I hope this fix finds its way to the master branch soon. 
