### PR TITLE
Fix redirection to active

### DIFF
--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -65,7 +65,7 @@ app.post('/job', provides('json'), express.bodyParser(), json.createJob);
 // routes
 
 app.get('/', function (req, res) {
-  res.redirect('/active')
+  res.redirect('active')
 });
 app.get('/active', routes.jobs('active'));
 app.get('/inactive', routes.jobs('inactive'));


### PR DESCRIPTION
The kue app has no knowledge of where it was mounted. Thus, we can't assume that '/active' is the right path.

For example, if we use path mouting:
app.use '/kue', kue.app

If we go to /kue, it redirects to /active instead of kue/active
