### PR TITLE
Fixed "Fork me on Github" ribbon.

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,6 @@
         </li>
       </ul>
     </div>
-<a href="http://github.com/learnboost/kue"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://d3nwyuy0nl342s.cloudfront.net/img/4c7dc970b89fd04b81c8e221ba88ff99a06c6b61/687474703a2f2f73332e616d617a6f6e6177732e636f6d2f6769746875622f726962626f6e732f666f726b6d655f72696768745f77686974655f6666666666662e706e67" alt="Fork me on GitHub"></a>
+<a href="http://github.com/learnboost/kue"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
   </body>
 </html>


### PR DESCRIPTION
The Fork me on GitHub ribbon is currently throwing a 404, this reverts the source of the image to the defaults supplied by GitHub.
