### PR TITLE
fire an event on Queue when all jobs are done

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -190,7 +190,21 @@ Queue.prototype.process = function(type, n, fn){
       });
 
       worker.on('job complete', function(job){
+
         self.client.incrby('q:stats:work-time', job.duration);
+
+        // TODO: perfect place to use promises, possibly via kriskowal/q
+        self.activeCount(function(err, activeCount){
+          self.delayedCount(function(err, delayedCount){
+            self.inactiveCount(function(err, inactiveCount){
+              total = activeCount + delayedCount + inactiveCount;
+              if (total == 0) self.emit('jobs all done', null);
+            });
+          });
+        });
+
+
+
       });
     })(new Worker(this, type).start(fn));
   }


### PR DESCRIPTION
I recommend we use promises via kriskowal/q to simplify the three levels of callbacks

this change closes LearnBoost/kue/issues/149
