### PR TITLE
Fixed bug in `Parallel Processing With Cluster` example code in `Readme.md`.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -378,10 +378,11 @@ if (cluster.isMaster) {
     var pending = 5
       , total = pending;
 
-    setInterval(function(){
+    var interval = setInterval(function(){
       job.log('sending!');
       job.progress(total - pending, total);
       --pending || done();
+      pending || clearInterval(interval);
     }, 1000);
   });
 }


### PR DESCRIPTION
The following example code from the [Parallel Processing With Cluster](https://github.com/LearnBoost/kue#parallel-processing-with-cluster) section of `Readme.md`

``` js
setInterval(function(){
  job.log('sending!');
  job.progress(total - pending, total);
  --pending || done();
}, 1000);
```

keeps on firing this Redis message

```
"q:job:123:log" "sending!"
"hset" "q:job:123" "updated_at" "1372407738102"
"hset" "q:job:123" "progress" "100"
"hset" "q:job:123" "updated_at" "1372407738102"
"publish" "q:events" "{\"id\":\"123\",\"event\":\"progress\",\"args\":[\"progress\",100]}"
```

even after a job is done. `clearInterval` needs to be called as follows

``` js
var interval = setInterval(function(){
  job.log('sending!');
  job.progress(total - pending, total);
  --pending || done();
  pending || clearInterval(interval);
}, 1000);
```
