### PR TITLE
Fix attempts.made and attempts.remaining from being undefined & NaN on first attempt

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -240,6 +240,9 @@ Job.prototype.toJSON = function(){
   if (!this._attempts) {
     this._attempts = 0;
   }
+  if (!this._max_attempts) {
+    this._max_attempts = 0;
+  }
   return {
       id: this.id
     , type: this.type


### PR DESCRIPTION
After the first run of a Job, the internal variable Job._attempts is still undefined.  The toJSON() function includes the attempts object which references this._attempts and does math based on it.  This results in invalid information being returned (namely, attempts is undefined and remaining is NaN).

This two line change will return 0 for attempts.made if _attempts is undefined, and will return max_attempts for attempts.remaining.
