### PR TITLE
Changed redis default port to 6379 in Readme.md, closes #122

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -238,7 +238,7 @@ jobs.process('slideshow pdf', 5, function(job, done){
 
 ## Redis Connection Settings
 
-  By default, Kue will connect to Redis using the client default settings (port defaults to `6389`, host defaults to `127.0.0.1`).  Redis client connection settings can be set by overriding the `kue.redis.createClient` function.
+  By default, Kue will connect to Redis using the client default settings (port defaults to `6379`, host defaults to `127.0.0.1`).  Redis client connection settings can be set by overriding the `kue.redis.createClient` function.
 
   For example, to create a Redis client that connects to `192.168.1.2` on port `1234` that requires authentication, use the following:
 


### PR DESCRIPTION
I've changed to default port for redis in the docs to 6379 (http://redis.io/topics/quickstart) as mentioned in #122
