### PR TITLE
Delaying failed jobs - fixed delay or exponential backoff + other fixes

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -127,16 +127,19 @@ Queue.prototype.promote = function(ms){
       , 'get', '#'
       , 'get', 'q:job:*->delay'
       , 'get', 'q:job:*->created_at'
+      , 'get', 'q:job:*->failed_at'
       , 'limit', 0, limit, function(err, jobs){
       if (err || !jobs.length) return;
 
       // iterate jobs with [id, delay, created_at]
       while (jobs.length) {
-        var job = jobs.slice(0, 3)
+        var job = jobs.slice(0, 4)
           , id = parseInt(job[0], 10)
           , delay = parseInt(job[1], 10)
           , creation = parseInt(job[2], 10)
-          , promote = ! Math.max(creation + delay - Date.now(), 0);
+          , failure = parseInt(job[3], 10)
+          , base = Math.max(creation, failure)
+          , promote = ! Math.max(base + delay - Date.now(), 0);
 
         // if it's due for activity
         // "promote" the job by marking
@@ -148,8 +151,7 @@ Queue.prototype.promote = function(ms){
             job.inactive();
           });
         }
-
-        jobs = jobs.slice(3);
+        jobs = jobs.slice(4);
       }
     });
   }, ms);
@@ -284,6 +286,15 @@ Queue.prototype.inactive = function(fn){
 Queue.prototype.active = function(fn){
   return this.state('active', fn);
 };
+
+/**
+ * Delayed jobs (waiting).
+ */
+
+Queue.prototype.delayed = function(fn){
+  return this.state('delayed', fn);
+};
+
 
 /**
  * Completed jobs count.

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -160,6 +160,8 @@ exports.get = function(id, fn){
     // we can just merge these
     job.type = hash.type;
     job._delay = hash.delay;
+    job._retry_delay = hash.retry_delay || 0;
+    job._retry_delay_type = hash.retry_delay_type || 'exponential';
     job.priority(Number(hash.priority));
     job._progress = hash.progress;
     job._attempts = hash.attempts;
@@ -250,6 +252,10 @@ Job.prototype.toJSON = function(){
     , failed_at: this.failed_at
     , duration: this.duration
     , delay: this._delay
+    , retry_delay: {
+        delay: this._retry_delay
+      , type: this.retry_delay_type
+    }
     , attempts: {
         made: this._attempts
       , remaining: this._max_attempts - this._attempts
@@ -354,8 +360,44 @@ Job.prototype.delay = function(ms){
   if (0 == arguments.length) return this._delay;
   this._delay = ms;
   this._state = 'delayed';
+  if (this.id) {
+    this.set('delay', this._delay);
+    this.state(this._state);
+  }
   return this;
 };
+
+/**
+ * Set the job's retry delay in `ms` and type
+ *
+ * @param {Number} ms
+ * @param {String} type
+ * @return {Job|Number}
+ * @api public
+ */
+
+Job.prototype.retryDelay = function(ms, type){
+  if (0 == arguments.length) return this._retry_delay;
+  this._retry_delay = ms;
+  if (type) this.retryDelayType(type);
+  return this;
+};
+
+/**
+ * Set the job's retry delay type - fixed or exponential
+ *
+ * @param {String} type
+ * @return {Job|String}
+ * @api public
+ */
+
+Job.prototype.retryDelayType = function(type){
+  if (0 == arguments.length) return this._retry_delay_type;
+  if (!type || type != 'fixed') type = 'exponential';
+  this._retry_delay_type = type;
+  return this;
+};
+
 
 /**
  * Set or get the priority `level`, which is one
@@ -582,6 +624,10 @@ Job.prototype.update = function(fn){
 
   // delay
   if (this._delay) this.set('delay', this._delay);
+
+  // retry delay
+  if (this._retry_delay) this.set('retry_delay', this._retry_delay);
+  if (this._retry_delay_type) this.set('retry_delay_type', this._retry_delay_type);
 
   // updated timestamp
   this.set('updated_at', Date.now());

--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -78,7 +78,7 @@ Worker.prototype.start = function(fn){
 
 Worker.prototype.error = function(err, job){
   // TODO: emit non "error"
-  console.error(err.stack || err.message);
+  console.error(err.stack || err.message || err);
   return this;
 };
 
@@ -100,9 +100,22 @@ Worker.prototype.failed = function(job, err, fn){
   self.error(err, job);
   job.attempt(function(error, remaining, attempts, max){
     if (error) return self.error(error, job);
-    remaining
-      ? job.inactive()
-      : job.failed();
+    if (remaining) {
+      if (job.retryDelay()) {
+        var retry_delay = job.retryDelay() || job.delay();
+        if (retry_delay && job.retryDelayType() == 'exponential') {
+          retry_delay = Math.round(retry_delay * 0.5 * ( Math.pow(2, attempts) - 1));
+        } 
+        job.delay(retry_delay);
+      }
+      else if (job.delay()) {
+        job.delay(job.delay());
+      } else {
+        job.inactive();
+      }
+    } else {
+      job.failed();
+    }
     self.start(fn);
   });
 };


### PR DESCRIPTION
- Support for delaying failed jobs - with fixed delay for each retry or exponential backoff calculation.
- Way to get all delayed jobs from the queue.
- Fix fo delay() not saving
- Fix for "undefined" showing up via console.error when jobs failed and the error passed was a string
- Honor original delay when retrying failed jobs - instead of processing them right away
