### PR TITLE
Suppress "undefined" messages in console where string errors are passed

### DIFF
--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -78,7 +78,7 @@ Worker.prototype.start = function(fn){
 
 Worker.prototype.error = function(err, job){
   // TODO: emit non "error"
-  console.error(err.stack || err.message);
+  console.error(err.stack || err.message || err);
   return this;
 };
 


### PR DESCRIPTION
Without this, "undefined" shows up in the console every time an error is passed via .error(String). This patch will attempt to display the err "object" as a fallback when the default behaviors fail.
