### PR TITLE
When creating Queue get all currently active jobs and set their status t...

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -75,12 +75,15 @@ exports.createQueue = function(){
 
 function Queue() {
   this.client = redis.createClient();
-  Job.rangeByState('active', 0, -1, 'asc', function (err, jobs) {
-    if (err) self.error(err, job);
-    jobs.forEach(function (job) {
-      job.inactive();
+
+  if (require('cluster').isMaster) {
+    Job.rangeByState('active', 0, -1, 'asc', function (err, jobs) {
+      if (err) self.error(err, job);
+      jobs.forEach(function (job) {
+        job.inactive();
+      });
     });
-  });
+  }
 }
 
 /**


### PR DESCRIPTION
If we kill node process running kue the existing active jobs remain and are not actually running (after restart). So we need to initially mark them as inactive, so they can be run again by Worker. 
