### PR TITLE
Fixing Cannot read property 'id' of undefined issue

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -155,7 +155,7 @@ exports.get = function(id, fn){
   client.hgetall('q:job:' + job.id, function(err, hash){
     if (err) return fn(err);
     if (!hash) return fn(new Error('job "' + job.id + '" doesnt exist'));
-    if (!hash.type) return fn();
+    if (!hash.type) return fn(new Error('job "' + job.id + '" is invalid'));
     // TODO: really lame, change some methods so 
     // we can just merge these
     job.type = hash.type;


### PR DESCRIPTION
This isn't a full fix as what it does is let kue bypass broken records.
