### PR TITLE
Ensure callers can't have loads of timers running

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -74,6 +74,7 @@ exports.createQueue = function(){
 
 function Queue() {
   this.client = redis.createClient();
+  this.promoter = null;
 }
 
 /**
@@ -121,7 +122,8 @@ Queue.prototype.promote = function(ms){
     , ms = ms || 5000
     , limit = 20;
 
-  setInterval(function(){
+  clearInterval(this.promoter);
+  this.promoter = setInterval(function(){
     client.sort('q:jobs:delayed'
       , 'by', 'q:job:*->delay'
       , 'get', '#'


### PR DESCRIPTION
Its not completely obvious that calling promote() multiple times will trigger many timers.

Its also not very difficult to protect callers from this, so here's a patch to do this.

I've recently been tracking down a memory leak that ended up being caused by promote() being called in a different Interval timer loop.
