### PR TITLE
Fix for exceptions thrown in user job processing code are being silently caught and discarded

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -170,9 +170,9 @@ exports.get = function (id, fn) {
         job.failed_at = hash.failed_at;
         job.duration = hash.duration;
         try {
-          if (hash.data) job.data = JSON.parse(hash.data);
+            if (hash.data) job.data = JSON.parse(hash.data);
         } catch (err) {
-          return fn(err);
+            return fn(err);
         }
         fn(err, job);
     });


### PR DESCRIPTION
Bug in lib/queue/job.js#get:

```
        try {
            if (hash.data) job.data = JSON.parse(hash.data);
            fn(err, job);
        } catch (err) {
            fn(err);
        }
```

As a result of `process.nextTick` being commented out later along execution, this innocuous looking try catch was actually catching all exceptions thrown in user provided functions to queue.process silently.

ie.

```
jobs.process('task', function(job, done){
    throw "Error";
});
```

Would silently fail without any output / event.

Fixed by rearranging the try / catch.
