### PR TITLE
Remove console.log

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -632,7 +632,7 @@ Job.prototype.update = function (fn) {
 
     if( !exports.disableSearch ) {
       getSearch().index(json, this.id, function(){
-          console.log( "add index...");
+          //console.log( "add index..."); // leaving this in causes a ton of logging to happen.
       }.bind(this));
     }
 };


### PR DESCRIPTION
I just updated to 0.7.4 and had a ton of these messages streaming in my log, all of a sudden.
