### PR TITLE
Fix bug in Job state method which would fail if no callback was provided

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -508,14 +508,16 @@ Job.prototype.state = function (state, fn) {
  */
 
 Job.prototype.error = function (err) {
+    var str, summary;
+
     if (0 == arguments.length) return this._error;
 
     if ('string' == typeof err) {
-        var str = err
-            , summary = '';
+        str = err;
+        summary = '';
     } else {
-        var str = err.stack || err.message
-            , summary = str.split('\n')[0];
+        str = err.stack || err.message;
+        summary = str ? str.split('\n')[0] : '';
     }
 
     this.set('failed_at', Date.now());


### PR DESCRIPTION
Specifically this resulted in a lot of errors in our logs that looked like this:

```
TypeError: undefined is not a function
    at Job.<anonymous> (/omitted.../node_modules/kue/lib/queue/job.js:494:87)
    at try_callback (/omitted.../node_modules/redis/index.js:581:9)
    at RedisClient.return_reply (/omitted.../node_modules/redis/index.js:671:13)
    at ReplyParser.<anonymous> (/omitted.../node_modules/redis/index.js:313:14)
    at ReplyParser.EventEmitter.emit (events.js:95:17)
    at ReplyParser.send_reply (/omitted.../node_modules/redis/lib/parser/javascript.js:300:10)
    at ReplyParser.execute (/omitted.../node_modules/redis/lib/parser/javascript.js:189:22)
    at RedisClient.on_data (/omitted.../node_modules/redis/index.js:536:27)
    at Socket.<anonymous> (/omitted.../node_modules/redis/index.js:91:14)
    at Socket.EventEmitter.emit (events.js:95:17)
```

(omitted some particulars of my setup)

This commit and pull request fixes that issue.
