### PR TITLE
Reuse redis client

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -95,7 +95,7 @@ function Queue( options ) {
             return client;
         };
     }
-    this.client = Worker.client = redis.createClient();
+    this.client = Worker.client = Job.client = redis.createClient();
     this.promoter = null;
     this.workers = exports.workers;
     Job.disableSearch = options.disableSearch;

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -221,7 +221,7 @@ exports.log = function (id, fn) {
 function Job(type, data) {
     this.type = type;
     this.data = data || {};
-    this.client = redis.client();
+    this.client = Job.client || (Job.client = redis.client());
     this.priority('normal');
     this.on("error", function(err){});// prevent uncaught exceptions on failed job errors
 }


### PR DESCRIPTION
Simply initialize Worker.client and Job.client with redis client from Queue for reuse. 
This saves 1 redis connection per core on worker, and 1 connection per core per job type on job creation. Worker still needs a separate connection for `blpop`. 
