### PR TITLE
Handle errors emitted by redis by listening on error event to avoid process to exit

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -85,6 +85,7 @@ function Queue( options ) {
     options = options || {};
     if( options.redis ){
         redis.createClient = function() {
+            var self = this;
             //    redis.debug_mode = true;
             var port = options.redis.port || 6379;
             var host = options.redis.host || '127.0.0.1';
@@ -92,8 +93,11 @@ function Queue( options ) {
             if (options.redis.auth) {
                 client.auth(options.redis.auth);
             }
+            client.on('error', function (err) {
+                self.emit('error', err);
+            });
             return client;
-        };
+        }.bind(this);
     }
     this.client = redis.createClient();
     this.promoter = null;


### PR DESCRIPTION
See http://nodejs.org/api/events.html#events_class_events_eventemitter

> When an EventEmitter instance experiences an error, the typical action is to emit an 'error' event. Error events are treated as a special case in node. If there is no listener for it, then the default action is to print a stack trace and exit the program.

Redis emits errors in several places e.g. https://github.com/mranney/node_redis/blob/master/index.js#L185. As they are not listened to currently, the process crashes. With this change, errors are listened on the redis client and emitted back to the queue.
