### PR TITLE
update job toggles & log selection issues

### DIFF
--- a/lib/http/public/javascripts/job.js
+++ b/lib/http/public/javascripts/job.js
@@ -131,7 +131,7 @@ Job.prototype.render = function (isNew) {
         });
 
         // show details
-        view.el.toggle(function () {
+        view.el.find('.contents').toggle(function () {
             view.details().addClass('show');
             self.showDetails = true;
         }, function () {
@@ -236,6 +236,10 @@ Job.prototype.renderUpdate = function () {
     if (this.showDetails) {
         request('GET', './job/' + this.id + '/log', function (log) {
             var ul = view.log.show();
+            
+            // return early if log hasnt changed
+            if (ul.text() === log) return;
+            
             ul.find('li').remove();
             log.forEach(function (line) {
                 ul.append(o('<li>%s</li>', line));


### PR DESCRIPTION
Right now you can't really select and copy past your job log.
The job view toggle on click and log text is refreshed every 3sec
which make it hard to select anything..

So this is a quick fix to:
- restraint toggle to the content div
- Refresh log when text changes only
