### PR TITLE
Always emit errors, even if they are worker errors. 

### DIFF
--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -93,9 +93,9 @@ Worker.prototype.error = function (err, job, asWorkerError) {
     }
     if( asWorkerError === false ) {
         job && job.id && events.emit(job.id, 'error', errorObj);
-    } else {
-        this.emit('error', errorObj, job);
-    }
+    } 
+    this.emit('error', errorObj, job);
+    
 //    console.error(err.stack || err.message || err);
     return this;
 };


### PR DESCRIPTION
This allows us to handle errors in code and pass them to a centralized error handler like sentry.
