### PR TITLE
Possible fix for shutdown error - NEEDS REVIEW

### DIFF
--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -241,8 +241,6 @@ Worker.prototype.getJob = function (fn) {
                 fn(err /*||"shutdown pushback"*/);
             });
         }
-        // Set job to a temp value so shutdown() knows to wait
-        self.job = true;
         self.zpop('q:jobs:' + self.type + ':inactive', function (err, id) {
             if (err || !id) {
                 self.job = false;


### PR DESCRIPTION
In my own application I'm seeing intermittent failures during Kue shutdown:

```
     Uncaught TypeError: Object true has no method 'error'
      at Worker.failed (/vagrant/node_modules/kue/lib/queue/worker.js:113:9)
      at Worker.<anonymous> (/vagrant/node_modules/kue/lib/queue/worker.js:296:22)
      at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)
```

It looks like events are happening such that `getJob` sets `self.job = true` but
does not finish the the `zpop` and then shutdown calls `failed` to mark the job
as failed during shutdown.  The problem is that the `job` passed into `Worker.failed`
is true and not an actual Job object, hence the type error.

I don't fully understand all the branches of this code path so I'm not sure if
removing the `self.job = true` can cause problems in some cases.

I'm attempting to create a test case that captures this condition so it can be
reliably tested.  Please take a look and see if this change breaks certain
scenarios that I'm not seeing in my app (for example, I don't use pause/resume
which may be the reason for this code).  Existing tests pass when this line is removed.
