### PR TITLE
Fix positioning in styles

### DIFF
--- a/lib/http/public/stylesheets/actions.styl
+++ b/lib/http/public/stylesheets/actions.styl
@@ -1,6 +1,6 @@
 
 #actions
-  fixed: top - 2px right - 2px
+  fixed: top -2px right -2px
   z-index: 20
 
 #sort

--- a/lib/http/public/stylesheets/error.styl
+++ b/lib/http/public/stylesheets/error.styl
@@ -1,6 +1,6 @@
 
 #error
-  fixed: top - 50px right 15px
+  fixed: top -50px right 15px
   padding: 20px
   transition: top 500ms, opacity 500ms
   opacity: 0

--- a/lib/http/public/stylesheets/job.styl
+++ b/lib/http/public/stylesheets/job.styl
@@ -17,7 +17,7 @@ bar(color)
   padding: 20px 25px
   h2
     margin: 0
-    absolute: top 5px left - 15px
+    absolute: top 5px left -15px
     padding: 5px
     font-size: 10px
     border-radius: left 5px right 2px
@@ -49,7 +49,7 @@ bar(color)
     border-radius: 2px
     font-size: 10px
   .remove
-    absolute: top 30px right - 6px
+    absolute: top 30px right -6px
     background: white
     display: block
     width: size = 20px

--- a/lib/http/public/stylesheets/menu.styl
+++ b/lib/http/public/stylesheets/menu.styl
@@ -38,5 +38,5 @@
       &:active
       &.active
         background: #343434
-        box-shadow: inset 0 0 3px 2px menu-bg - 30%, inset 0 - 5px 10px 2px menu-bg - 15%
+        box-shadow: inset 0 0 3px 2px menu-bg - 30%, inset 0 -5px 10px 2px menu-bg - 15%
         border-bottom: 1px solid menu-bg - 40%


### PR DESCRIPTION
It looks like 356a314 introduced some extra whitespace for a few negative CSS values causing them to break. Removing the whitespace seems to put everything back in the appropriate place.
