### PR TITLE
fix running job infinitely when attempts < 0

### DIFF
--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -117,7 +117,7 @@ Worker.prototype.failed = function (job, err, fn) {
             /*remaining
              ? job.inactive()
              : job.failed();*/
-            if (remaining) {
+            if (remaining > 0) {
                 self.emit('job failed attempt', job);
                 events.emit(job.id, 'failed attempt', attempts);
                 if (job.delay()) { //TODO WHEN should we honor the original delay in retries?


### PR DESCRIPTION
I just run into issue where job with 3 max_attempts made 16521 attempts, -16518 remaining.
Still no idea how that could happen, but you should be trying again only if attempts > 0, not if attempts != 0.
