### PR TITLE
Get number of jobs with given state and type.

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -358,8 +358,9 @@ Queue.prototype.workTime = function (fn) {
 };
 
 /**
- * Get cardinality of `state`  and `tyep` and callback `fn(err, n)`.
+ * Get cardinality of jobs with given `state` and `type` and callback `fn(err, n)`.
  *
+ * @param {String} type
  * @param {String} state
  * @param {Function} fn
  * @return {Queue} for chaining


### PR DESCRIPTION
Added a `cardByType` function which behaves like the `card` function but also specifies a job type.
