### PR TITLE
Add Queue.prototype.delayed function

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -404,6 +404,14 @@ Queue.prototype.active = function (fn) {
 };
 
 /**
+ * Delayed jobs.
+ */
+
+Queue.prototype.delayed = function (fn) {
+    return this.state('delayed', fn);
+};
+
+/**
  * Completed jobs count.
  */
 


### PR DESCRIPTION
Queue.prototype.delayed appears to be missing, added to complete the suite (and I need it).
