### PR TITLE
fix redirection

### DIFF
--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -66,7 +66,7 @@ app.post('/job', provides('json'), express.bodyParser(), json.createJob);
 
 app.get('/', function (req, res) {
 //    res.redirect('active')
-    (app.path() === '/') ? res.redirect('/active') : res.redirect('active');
+    res.redirect(app.path()+'active');
 });
 app.get('/active', routes.jobs('active'));
 app.get('/inactive', routes.jobs('inactive'));


### PR DESCRIPTION
When the app is mounted on /kue for example, http://www.domain.com/kue/ redirects to http://www.domain.com/kue/active BUT http://www.domain.com/kue redirects to http://www.domain.com/active
