### PR TITLE
emit event 'job failed attempt' after job successfully updated

### DIFF
--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -109,8 +109,11 @@ Worker.prototype.failed = function (job, err, fn) {
         job.attempt(function (error, remaining, attempts, max) {
             if (error) return self.error(error, job);
             if (remaining) {
-                self.emit('job failed attempt', job);
-                events.emit(job.id, 'failed attempt', attempts);
+                var emit = function () {
+                    self.emit('job failed attempt', job);
+                    events.emit(job.id, 'failed attempt', attempts);
+                };
+
                 if ( job.backoff() ) {
                     var delay = job.delay();
                     if( _.isFunction( job._getBackoffImpl() ) ) {
@@ -120,9 +123,9 @@ Worker.prototype.failed = function (job, err, fn) {
                             self.error( e, job );
                         }
                     }
-                    job.delay( delay ).update();
+                    job.delay( delay ).update(emit);
                 } else {
-                    job.inactive();
+                    job.inactive(emit);
                 }
             } else {
                 self.emit('job failed', job);


### PR DESCRIPTION
If we do `queue.shutdown` like below as written in document:

``` javascript
var queue = require('kue').createQueue();

process.once( 'SIGTERM', function ( sig ) {
  queue.shutdown(function(err) {
    console.log( 'Kue is shut down.', err||'' );
    process.exit( 0 );
  }, 5000 );
});
```

`queue.shutdown` will listens for event `'job failed attempt'` and calls callback function of `queue.shutdown`, which will eventually call `process.exit`.

Therefore, `'job failed attempt'` should be emitted **AFTER** job status update finishes (delay or inactive).

Otherwise, job requiring attempt can be stuck on failed status.
