### PR TITLE
Fix allowing kue app to be hosted as child of another parent express app

### DIFF
--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -65,7 +65,7 @@ app.post('/job', provides('json'), express.bodyParser(), json.createJob);
 // routes
 
 app.get('/', function (req, res) {
-    res.redirect(req.baseUrl +'/active');
+    res.redirect(app.path() +'/active');
 });
 app.get('/active', routes.jobs('active'));
 app.get('/inactive', routes.jobs('inactive'));


### PR DESCRIPTION
With this added slash in the base path redirect, the kue app performs correct redirects if it is hosted as part of a parent express app, on its own dedicated path, like so:

``` js
var app = require('express')(); // parent express app
app.use('/kueapp', require('kue').app); // we want the kue UI to be available on the 'kueapp' subpath
app.listen(1337); // the kue app is now available on http://localhost:1337/kueapp
```

This fixes the current failing behavior, as a redirect without the slash sends the user to http://localhost:1337/kueappactive, which returns 404.
