### PR TITLE
req.baseUrl is more right for current express version (3.x)

### DIFF
--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -66,7 +66,7 @@ app.post('/job', provides('json'), express.bodyParser(), json.createJob);
 
 app.get('/', function (req, res) {
 //    res.redirect('active')
-    res.redirect(app.path()+'active');
+    res.redirect(req.baseUrl+'/active');
 });
 app.get('/active', routes.jobs('active'));
 app.get('/inactive', routes.jobs('inactive'));


### PR DESCRIPTION
app.mountpath for 4.x

this code is more reliable for following situation:
### express 4.x app with kue app (express 3.x)

``` javascript
var express = require('express');
var app = express();
var router = express.Router();
var kue = require('kue');
router.use('/some/where/watchtower', auth.mid.requirePermission(Permission.TO.Watch), kue.app);
```

in case of upgrading kue's express 3.x to 4.x,

``` javascript
res.redirect(app.mountpath + '/active');
```

rather than 

``` javascript
res.redirect(req.baseUrl+'/active');
```

will be more durable.
