### PR TITLE
fix `cleanup` global leak

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -263,7 +263,7 @@ Queue.prototype.shutdown = function (fn, timeout, type) {
         , n = self.workers.length
         , type = type || '';
 
-    cleanup = function () {
+    var cleanup = function () {
         if (type == '') {
             self.client && self.client.quit();
             self.client = null;


### PR DESCRIPTION
Hey guys,

I found that every time I pause a worker, it creates a cleanup function in global object. This pull request is just add the `var` declaration for the cleanup function.

Thanks 
