### PR TITLE
Added `filterByData` method and its test.

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -12,7 +12,8 @@ var EventEmitter = require('events').EventEmitter
     , Worker = require('./queue/worker')
     , events = require('./queue/events')
     , Job = require('./queue/job')
-    , redis = require('./redis');
+    , redis = require('./redis')
+    , _ = require('lodash');
 
 /**
  * Expose `Queue`.
@@ -382,6 +383,46 @@ Queue.prototype.cardByType = function (type, state, fn) {
 
 Queue.prototype.card = function (state, fn) {
     this.client.zcard(this.client.getKey('jobs:' + state), fn);
+    return this;
+};
+
+/**
+ * Filter jobs by `type` and `state` and callback `fn(err, jobs)`.
+ *
+ * @param {String} type
+ * @param {String} state
+ * @param {Object} condition
+ * @param {Function} fn
+ * @return {Queue} for chaining
+ * @api public
+ */
+Queue.prototype.filterByData = function (type, state, condition, fn) {
+    this.cardByType(type, state, function (err, len) {
+        if (err) {
+            fn(err);
+        }
+        if (len) {
+            Job.rangeByType(type, state, 0, len, 'desc', function (err, jobs) {
+                if (err) {
+                    fn(err);
+                }
+                if (jobs) {
+                    fn(
+                        null,
+                        _.chain(jobs)
+                        .where({
+                            data: condition
+                        })
+                        .value()
+                    );
+                } else {
+                    fn(null, []);
+                }
+            });
+        } else {
+            fn(null, []);
+        }
+    });
     return this;
 };
 


### PR DESCRIPTION
Suggestion to improve the **kue**'s search capabilities by providing a method capable of filtering jobs from `type` in `state` having job.data which deeply equals a `condition` object.

This filter is useful for finding duplicates, answer questions related to search and could be used to solve problems like: #471, #440, #376, #267.

For usage see its [test](https://github.com/ColorfullyMe/kue/blob/filterByData/test/test.js#L58).
