### PR TITLE
Optional display of job.data in UI

### DIFF
--- a/lib/http/public/javascripts/job.js
+++ b/lib/http/public/javascripts/job.js
@@ -76,6 +76,23 @@ Job.prototype.render = function (isNew) {
         , keys = Object.keys(this.data).sort()
         , data;
 
+    /* 
+        remove user selected job's attributes from data table.
+    */
+    var do_not_show = this.data.do_not_show || [];
+
+    var index = keys.indexOf('do_not_show');
+    keys.splice(index, 1);
+
+    do_not_show.forEach(function (entry) {
+        index = keys.indexOf(entry);
+        keys.splice(index, 1);
+    });
+    /* 
+        endof tiny hack
+    */
+    
+    
     if (isNew) {
         view = this.view = View('job');
 


### PR DESCRIPTION
Some times its necessary to prevent from displaying the specific (user selected) job's attributes in data table.
I mean the table which toogle after clicking on each job in ui.

add "do_not_show" in job data aray as like as this samle:

```js
  var options = {
    url:'http://localhost:3000/job',
    json: {
      type: "email",
      data: {
        title: title,
        to: to,
        displayName: displayName,
        subject: subject,
        html: html,
        doNotShow: ['html', 'displayName'],
      },
      options: {
        attempts: 5,
        priority: "high"
      }
    }
  };
```