### PR TITLE
When adding multiple jobs via API, in case of error keep processing remaining jobs.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -700,7 +700,7 @@ Create a job:
          }' http://localhost:3000/job
     {"message": "job created", "id": 3}
 
-You can create multiple jobs at once by passing an array. In this case, the response will be an array too.
+You can create multiple jobs at once by passing an array. In this case, the response will be an array too, preserving the order:
 
     $ curl -H "Content-Type: application/json" -X POST -d \
         '[{
@@ -733,7 +733,7 @@ You can create multiple jobs at once by passing an array. In this case, the resp
 	    {"message": "job created", "id": 5}
     ]
 
-Note: when inserting multiple jobs in bulk, if one insertion fails Kue will not attempt adding the remaining jobs. The response array will contain the ids of the jobs added successfully, and the last element will be an object describing the error: `{"error": "error reason"}`. It is your responsibility to fix the wrong task and re-submit it and all the subsequent ones.
+Note: when inserting multiple jobs in bulk, if one insertion fails Kue will keep processing the remaining jobs in order. The response array will contain the ids of the jobs added successfully, and any failed element will be an object describing the error: `{"error": "error reason"}`.
 
 
 ## Parallel Processing With Cluster

--- a/lib/http/routes/json.js
+++ b/lib/http/routes/json.js
@@ -164,26 +164,34 @@ exports.createJob = function (req, res) {
         });
     }
 
-    if (body) {
+    if (!lodash.isEmpty(body)) {
         if (lodash.isArray(body)) {
+            var returnErrorCode = 0; // Default: we don't have any error
             var i = 0, len = body.length;
             var result = [];
             -function _iterate() {
                 _create(body[i], function(err, status, errCode) {
                     result.push(err || status);
                     if (err) {
-                        res.status(errCode || 500).json(result);
-                    }
-                    else {
-                        i++;
-                        if (i < len) {
-                            _iterate();
-                        }
-                        else {
-                            res.json(result);
+                        // Set an error code for the response
+                        if(!returnErrorCode) {
+                            returnErrorCode = errCode || 500;
                         }
                     }
                     
+                    // Keep processing even after an error
+                    i++;
+                    if (i < len) {
+                        _iterate();
+                    }
+                    else {
+                        // If we had an error code, return it
+                        if(returnErrorCode) {
+                            res.status(returnErrorCode);
+                        }
+                        
+                        res.json(result);
+                    }
                 })
             }()
         }
@@ -197,6 +205,10 @@ exports.createJob = function (req, res) {
                 }
             })
         }
+    }
+    else {
+        res.status(204); // "No content" status code
+        res.end();
     }
 };
 

--- a/test/jsonapi.js
+++ b/test/jsonapi.js
@@ -209,6 +209,17 @@ describe('JSON API', function() {
 
 
   describe('error cases', function() {
+    it('should return 204 status code when POST /job body is empty', function(done) {
+      request(app)
+        .post('/job')
+        .send([])
+        .expect(204)
+        .expect(function(res) {
+          res.text.should.have.lengthOf(0);
+        })
+        .end(done);
+    });
+    
     it('should insert jobs including an invalid job, respond with ids and error', function(done) {
       var jobs = jobsPopulate(3);
       delete jobs[1].type;
@@ -221,7 +232,7 @@ describe('JSON API', function() {
           var created = res.body;
 
           created.should.be.ok;
-          created.length.should.equal(2); // the second one failed
+          created.length.should.equal(3); // should still have 3 objects in the response
 
           // The first one succeeded
           created[0].message.should.be.equal('job created');
@@ -231,6 +242,11 @@ describe('JSON API', function() {
           // The second one failed
           created[1].error.should.equal('Must provide job type');
           Object.keys(created[1]).should.have.lengthOf(1);
+          
+          // The third one succeeded
+          created[2].message.should.be.equal('job created');
+          created[2].id.should.be.a.Number;
+          Object.keys(created[2]).should.have.lengthOf(2);
         })
         .end(done);
     });


### PR DESCRIPTION
Changed as requested by project maintainer on PR #527 .

Additionally, now the POST /jobs route will return a response when the request body is empty, instead of hanging.