### PR TITLE
Red job remove buttons and tooltips

### DIFF
--- a/lib/http/public/stylesheets/job.styl
+++ b/lib/http/public/stylesheets/job.styl
@@ -50,7 +50,8 @@ bar(color)
     font-size: 10px
   .remove
     absolute: top 30px right -6px
-    background: white
+    background: #F05151
+    color: white
     display: block
     width: size = 20px
     height: size

--- a/lib/http/views/_job.jade
+++ b/lib/http/views/_job.jade
@@ -1,7 +1,7 @@
 .job
     .block.contents
         h2.id
-        a.remove x
+        a.remove(title='Destroy Job') x
         canvas.progress(width=50, height=50)
         table.meta
             tbody
@@ -42,4 +42,3 @@
         .error
             pre
         ul.log
-    

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kue",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Feature rich priority job queue backed by redis",
   "homepage": "http://learnboost.github.com/kue/",
   "keywords": [


### PR DESCRIPTION
This PR makes the job remove buttons in the UI Red on hover, rather than white. It also adds simple tool tips to the same button.

The idea is to give the user a pinch more visual feedback since removing the job is a destructive action.

Before
===
![before](https://cloud.githubusercontent.com/assets/142910/7006093/4dfe455a-dc4c-11e4-8624-b024c9e7ea99.png)

After
===
![after](https://cloud.githubusercontent.com/assets/142910/7006095/5122d516-dc4c-11e4-9d70-5384dbe12c14.png)
