### PR TITLE
fix worker error object emit

### DIFF
--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -84,12 +84,7 @@ Worker.prototype.start = function (fn) {
  */
 
 Worker.prototype.error = function (err, job) {
-    var errorObj = err;
-    if( err.stack ) {
-        errorObj = { stack:err.stack, message:err.message };
-    }
-    this.emit('error', errorObj, job);
-//    console.error(err.stack || err.message || err);
+    this.emit('error', err, job);
     return this;
 };
 


### PR DESCRIPTION
No need to wrap the error in another object. This breaks instanceof
checks and loses any properties on the error object being wrapped.