### PR TITLE
fix(#592): bad redirect URL in old express versions

### DIFF
--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -65,7 +65,7 @@ app.post('/job', provides('json'), bodyParser.json(), json.createJob);
 // routes
 
 app.get('/', function( req, res ) {
-  var context = app.mountpath || req.baseUrl;
+  var context = app.mountpath || req.baseUrl || '/';
   res.redirect(context + 'active');
 });
 


### PR DESCRIPTION
Alternatively, it may also evaluate `req.originalUrl` as fallback option.