### PR TITLE
Remove old unlock call

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -193,7 +193,6 @@ Queue.prototype.checkJobPromotion = function( promotionOptions ) {
               job.inactive(doUnlock);
             });
           });
-          unlock();
         });
       } else {
         // The lock was not established by us, be silent


### PR DESCRIPTION
I'm dumb.  When I reverted some commits yesterday to clean up the PR commit, I only added the new code, and forgot to remove the old unlock call!  Sorry about that!