### PR TITLE
Move "delay" key on JSON API code example

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -744,10 +744,10 @@ You can create multiple jobs at once by passing an array. In this case, the resp
            "data": {
              "title": "followup email for tj",
              "to": "tj@learnboost.com",
-             "template": "followup-email",
-             "delay": 86400
+             "template": "followup-email"
            },
            "options" : {
+             "delay": 86400,
              "attempts": 5,
              "priority": "high"
            }


### PR DESCRIPTION
Just now working on creating delayed job using JSON API following the code example, but the delay didn't work. After 2 minutes digging into codes, shows that **delay** key supposed to be inside **options** not **data**