### PR TITLE
Get progress_data along with other redis fields

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -194,6 +194,7 @@ exports.get = function( id, fn ) {
     try {
       if( hash.data ) job.data = JSON.parse(hash.data);
       if( hash.result ) job.result = JSON.parse(hash.result);
+      if( hash.progress_data ) job.progress_data = JSON.parse(hash.progress_data);
       if( hash.backoff ) {
         var source = 'job._backoff = ' + hash.backoff + ";";
 //                require('vm').runInContext( source );
@@ -294,6 +295,7 @@ Job.prototype.toJSON = function() {
     , result: this.result
     , priority: this._priority
     , progress: this._progress || 0
+    , progress_data: this.progress_data
     , state: this._state
     , error: this._error
     , created_at: this.created_at


### PR DESCRIPTION
In Job.progress() one can use 3rd argument to push additional information:

```javascript
Job.prototype.progress = function( complete, total, data ) {
...
  if( data ) this.set('progress_data', JSON.stringify(data));
```

I find it very useful, but it was impossible to obtain this field using Job.range()