### PR TITLE
Test mode: Implement events and `Queue.process`

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -819,18 +819,12 @@ Enable test mode to push all jobs into a `jobs` array. Make assertions against
 the jobs in that array to ensure code under test is correctly enqueuing jobs.
 
 ```js
-queue = require('kue').createQueue();
+global.KUE_TEST_MODE = true;
 
-before(function() {
-  queue.testMode.enter();
-});
+queue = require('kue').createQueue();
 
 afterEach(function() {
   queue.testMode.clear();
-});
-
-after(function() {
-  queue.testMode.exit()
 });
 
 it('does something cool', function() {

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -632,4 +632,6 @@ Queue.prototype.delayedCount = function( type, fn ) {
  * @api public
  */
 
-Queue.prototype.testMode = require('./queue/test_mode');
+if (global.KUE_TEST_MODE) {
+  Queue.prototype.testMode = require('./queue/test_mode');
+}

--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -9,6 +9,7 @@ function testJobSave( fn ) {
   this.id = _.uniqueId;
   jobs.push(this);
   if( _.isFunction(fn) ) fn();
+  return this;
 };
 
 function testJobUpdate( fn ) {

--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -1,16 +1,23 @@
 var Job = require('./job'),
+  _ = require('lodash'),
+  Queue = require('./../kue'),
   originalJobSave   = Job.prototype.save,
   originalJobUpdate = Job.prototype.update,
+  originalQueueProcess = Queue.prototype.process,
   noop = function () {},
   idCounter = 0,
+  queue = Queue.createQueue(), // This is a singleton
   jobs;
 
 function testJobSave( fn ) {
+  var job = this;
+
   this.id = idCounter++;
   this.created_at = Date.now();
   this.promote_at = this.created_at + (this._delay || 0);
   jobs.push(this);
   this.emit('enqueue');
+  queue.emit('job enqueue', job.id, job.type);
   return this.update(fn);
 }
 
@@ -19,6 +26,28 @@ function testJobUpdate( fn ) {
   this.updated_at = Date.now();
   fn();
   return this;
+}
+
+function testQueueProcess(name, fn) {
+  queue.on('job enqueue', function(id, type) {
+    var job = _.find(jobs, function(queuedJob) {
+      return queuedJob.id === id;
+    });
+    var done = function(err, result) {
+      if (err) {
+        job.emit('failed', err.message);
+        queue.emit('job failed', job.id, err.message);
+      } else {
+        job.result = result;
+        job.emit('complete', result);
+        queue.emit('job complete', job.id, result);
+      }
+    };
+
+    if (name === type) {
+      fn(job, done);
+    }
+  });
 }
 
 /**
@@ -36,6 +65,7 @@ module.exports.jobs = jobs = [];
 module.exports.enter = function() {
   Job.prototype.save   = testJobSave;
   Job.prototype.update = testJobUpdate;
+  Queue.prototype.process = testQueueProcess;
 };
 
 /**
@@ -46,6 +76,7 @@ module.exports.enter = function() {
 module.exports.exit = function() {
   Job.prototype.save   = originalJobSave;
   Job.prototype.update = originalJobUpdate;
+  Queue.prototype.process = originalQueueProcess;
 };
 
 /**
@@ -56,4 +87,5 @@ module.exports.exit = function() {
 module.exports.clear = function() {
   jobs.length = 0;
   idCounter = 0;
+  queue.removeAllListeners();
 };

--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -17,7 +17,9 @@ function testJobSave( fn ) {
 }
 
 function testJobUpdate( fn ) {
+  this.updated_at = Date.now();
   if( _.isFunction(fn) ) fn();
+  return this;
 }
 
 /**

--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -6,7 +6,7 @@ var originalJobSave   = Job.prototype.save,
     jobs;
 
 function testJobSave( fn ) {
-  this.id = _.uniqueId;
+  this.id = parseInt(_.uniqueId());
   jobs.push(this);
   if( _.isFunction(fn) ) fn();
   return this;

--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -7,6 +7,7 @@ var Job = require('./job'),
   noop = function () {},
   idCounter = 0,
   queue = Queue.createQueue(), // This is a singleton
+  workers = [],
   jobs;
 
 function testJobSave( fn ) {
@@ -29,7 +30,7 @@ function testJobUpdate( fn ) {
 }
 
 function testQueueProcess(name, fn) {
-  queue.on('job enqueue', function(id, type) {
+  var worker = function(id, type) {
     var job = _.find(jobs, function(queuedJob) {
       return queuedJob.id === id;
     });
@@ -47,7 +48,10 @@ function testQueueProcess(name, fn) {
     if (name === type) {
       fn(job, done);
     }
-  });
+  };
+
+  workers.push(worker);
+  queue.on('job enqueue', worker);
 }
 
 /**
@@ -87,5 +91,8 @@ module.exports.exit = function() {
 module.exports.clear = function() {
   jobs.length = 0;
   idCounter = 0;
-  queue.removeAllListeners();
+  workers.forEach(function(worker) {
+    queue.removeListener('job enqueue', worker);
+  });
+  workers = [];
 };

--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -10,6 +10,7 @@ function testJobSave( fn ) {
   this.created_at = Date.now();
   this.promote_at = this.created_at + (this._delay || 0);
   jobs.push(this);
+  this.emit('enqueue');
   return this.update(fn);
 }
 

--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -10,11 +10,11 @@ function testJobSave( fn ) {
   jobs.push(this);
   if( _.isFunction(fn) ) fn();
   return this;
-};
+}
 
 function testJobUpdate( fn ) {
   if( _.isFunction(fn) ) fn();
-};
+}
 
 /**
  * Array of jobs added to the queue

--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -3,10 +3,11 @@ var Job = require('./job'),
 
 var originalJobSave   = Job.prototype.save,
     originalJobUpdate = Job.prototype.update,
+    idCounter = 0,
     jobs;
 
 function testJobSave( fn ) {
-  this.id = parseInt(_.uniqueId());
+  this.id = idCounter++;
   jobs.push(this);
   if( _.isFunction(fn) ) fn();
   return this;

--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -1,24 +1,22 @@
 var Job = require('./job'),
-    _   = require('lodash');
-
-var originalJobSave   = Job.prototype.save,
-    originalJobUpdate = Job.prototype.update,
-    idCounter = 0,
-    jobs;
+  originalJobSave   = Job.prototype.save,
+  originalJobUpdate = Job.prototype.update,
+  noop = function () {},
+  idCounter = 0,
+  jobs;
 
 function testJobSave( fn ) {
   this.id = idCounter++;
   this.created_at = Date.now();
   this.promote_at = this.created_at + (this._delay || 0);
-  this.updated_at = this.created_at;
   jobs.push(this);
-  if( _.isFunction(fn) ) fn();
-  return this;
+  return this.update(fn);
 }
 
 function testJobUpdate( fn ) {
+  fn = fn || noop;
   this.updated_at = Date.now();
-  if( _.isFunction(fn) ) fn();
+  fn();
   return this;
 }
 

--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -8,6 +8,9 @@ var originalJobSave   = Job.prototype.save,
 
 function testJobSave( fn ) {
   this.id = idCounter++;
+  this.created_at = Date.now();
+  this.promote_at = this.created_at + (this._delay || 0);
+  this.updated_at = this.created_at;
   jobs.push(this);
   if( _.isFunction(fn) ) fn();
   return this;

--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -1,16 +1,13 @@
 var Job = require('./job'),
   _ = require('lodash'),
   Queue = require('./../kue'),
-  originalJobSave   = Job.prototype.save,
-  originalJobUpdate = Job.prototype.update,
-  originalQueueProcess = Queue.prototype.process,
   noop = function () {},
   idCounter = 0,
   queue = Queue.createQueue(), // This is a singleton
   workers = [],
   jobs;
 
-function testJobSave( fn ) {
+Job.prototype.save = function( fn ) {
   var job = this;
 
   this.id = idCounter++;
@@ -20,16 +17,16 @@ function testJobSave( fn ) {
   this.emit('enqueue');
   queue.emit('job enqueue', job.id, job.type);
   return this.update(fn);
-}
+};
 
-function testJobUpdate( fn ) {
+Job.prototype.update = function( fn ) {
   fn = fn || noop;
   this.updated_at = Date.now();
   fn();
   return this;
-}
+};
 
-function testQueueProcess(name, fn) {
+Queue.prototype.process = function(name, fn) {
   var worker = function(id, type) {
     var job = _.find(jobs, function(queuedJob) {
       return queuedJob.id === id;
@@ -52,7 +49,7 @@ function testQueueProcess(name, fn) {
 
   workers.push(worker);
   queue.on('job enqueue', worker);
-}
+};
 
 /**
  * Array of jobs added to the queue
@@ -60,28 +57,6 @@ function testQueueProcess(name, fn) {
  */
 
 module.exports.jobs = jobs = [];
-
-/**
- * Enable test mode.
- * @api public
- */
-
-module.exports.enter = function() {
-  Job.prototype.save   = testJobSave;
-  Job.prototype.update = testJobUpdate;
-  Queue.prototype.process = testQueueProcess;
-};
-
-/**
- * Disable test mode.
- * @api public
- */
-
-module.exports.exit = function() {
-  Job.prototype.save   = originalJobSave;
-  Job.prototype.update = originalJobUpdate;
-  Queue.prototype.process = originalQueueProcess;
-};
 
 /**
  * Clear the array of queued jobs

--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -51,4 +51,5 @@ module.exports.exit = function() {
 
 module.exports.clear = function() {
   jobs.length = 0;
+  idCounter = 0;
 };

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -13,6 +13,23 @@
 var redis = require('redis');
 var url   = require('url');
 
+/** Mock Redis for Testing Mode
+ *
+ */
+
+if (global.KUE_TEST_MODE) {
+  var util = require('util');
+  var events = require('events');
+
+  var MockRedisClient = function() {};
+
+  util.inherits(MockRedisClient, events.EventEmitter);
+
+  MockRedisClient.prototype.getKey = function() {};
+  MockRedisClient.prototype.subscribe = function(channel) {};
+  MockRedisClient.prototype.publish = function(channel, msg) {};
+}
+
 /**
  *
  * @param options
@@ -53,6 +70,10 @@ exports.configureFactory = function( options, queue ) {
    * @api private
    */
   exports.createClient = function() {
+    if (global.KUE_TEST_MODE) {
+      return new MockRedisClient();
+    }
+
     var clientFactoryMethod = options.redis.createClientFactory || exports.createClientFactory;
     var client              = clientFactoryMethod(options);
     client.on('error', function( err ) {
@@ -63,6 +84,7 @@ exports.configureFactory = function( options, queue ) {
     client.getKey = function( key ) {
       return this.prefix + ':' + key;
     };
+
     return client;
   };
 };

--- a/test/test_mode.js
+++ b/test/test_mode.js
@@ -1,81 +1,65 @@
 var kue = require('../'),
-    _ = require('lodash'),
-    chai    = require( 'chai' ),
-    queue = kue.createQueue();
-
-expect = chai.expect;
+  queue = kue.createQueue(),
+  expect = require('chai').expect;
 
 describe('Test Mode', function() {
-    context('when enabled', function() {
-        before(function() {
-            queue.testMode.enter();
-        });
+  context('when enabled', function() {
+    before(function() { queue.testMode.enter(); });
+    afterEach(function() { queue.testMode.clear(); });
 
-        afterEach(function() {
-            queue.testMode.clear();
-        });
+    describe('#save', function() {
+      it('adds jobs to an array in memory', function() {
+        var job = queue.createJob('myJob', { foo: 'bar' }).save();
+        var jobs = queue.testMode.jobs;
+        expect(jobs.length).to.equal(1);
+        expect(jobs[0]).to.equal(job);
+      });
 
-        it('adds jobs to an array in memory', function() {
-            queue.createJob('myJob', { foo: 'bar' }).save();
+      it('adds an auto incrementing ID', function() {
+        var job = queue.createJob('myJob', { first: true }).save();
+        var anotherJob = queue.createJob('myJob', { first: false }).save();
+        expect(job.id).to.equal(0);
+        expect(anotherJob.id).to.equal(1);
+      });
 
-            var jobs = queue.testMode.jobs;
-            expect(jobs.length).to.equal(1);
-
-            var job = _.last(jobs);
-            expect(job.type).to.equal('myJob');
-            expect(job.data).to.eql({ foo: 'bar' });
-        });
-
-        it('returns the Job when saving', function() {
-            var job = queue.createJob('myJob', { foo: 'bar' });
-            var savedJob = job.save();
-            expect(savedJob).to.equal(job);
-        });
-
-        it('adds an auto incrementing ID when saving a Job', function() {
-          var job = queue.createJob('myJob', { first: true }).save();
-          var anotherJob = queue.createJob('myJob', { first: false }).save();
-          expect(job.id).to.equal(0);
-          expect(anotherJob.id).to.equal(1);
-        });
-
-        it('sets the timestamps when saving a Job', function() {
-          var job = queue.createJob('myJob', {}).save();
-          expect(job.created_at).to.exist;
-          expect(job.promote_at).to.exist;
-          expect(job.updated_at).to.exist;
-        });
-
-        describe('#clear', function() {
-            it('resets the list of jobs', function() {
-                queue.createJob('myJob', { foo: 'bar' }).save();
-                queue.testMode.clear();
-
-                var jobs = queue.testMode.jobs;
-                expect(jobs.length).to.equal(0);
-            });
-        });
+      it('sets the timestamps', function() {
+        var job = queue.createJob('myJob', {}).save();
+        expect(job.created_at).to.exist;
+        expect(job.promote_at).to.exist;
+        expect(job.updated_at).to.exist;
+      });
     });
 
-    context('when disabled', function() {
-        before(function() {
-            // Simulate entering and exiting test mode to ensure
-            // state is restored correctly.
-            queue.testMode.enter();
-            queue.testMode.exit();
-        });
+    describe('#clear', function() {
+      it('resets the list of jobs', function() {
+        queue.createJob('myJob', { foo: 'bar' }).save();
+        queue.testMode.clear();
 
-        it('processes jobs regularly', function(done) {
-            queue.createJob('myJob', { foo: 'bar' }).save();
-
-            var jobs = queue.testMode.jobs;
-            expect(jobs.length).to.equal(0);
-
-            queue.process('myJob', function (job, jdone) {
-                expect(job.data).to.eql({ foo: 'bar' });
-                jdone();
-                done();
-            });
-        });
+        var jobs = queue.testMode.jobs;
+        expect(jobs.length).to.equal(0);
+      });
     });
+  });
+
+  context('when disabled', function() {
+    before(function() {
+      // Simulate entering and exiting test mode to ensure
+      // state is restored correctly.
+      queue.testMode.enter();
+      queue.testMode.exit();
+    });
+
+    it('processes jobs regularly', function(done) {
+      queue.createJob('myJob', { foo: 'bar' }).save();
+
+      var jobs = queue.testMode.jobs;
+      expect(jobs.length).to.equal(0);
+
+      queue.process('myJob', function (job, jdone) {
+        expect(job.data).to.eql({ foo: 'bar' });
+        jdone();
+        done();
+      });
+    });
+  });
 });

--- a/test/test_mode.js
+++ b/test/test_mode.js
@@ -1,6 +1,9 @@
 var kue = require('../'),
     _ = require('lodash'),
+    chai    = require( 'chai' ),
     queue = kue.createQueue();
+
+expect = chai.expect;
 
 describe('Test Mode', function() {
     context('when enabled', function() {

--- a/test/test_mode.js
+++ b/test/test_mode.js
@@ -26,6 +26,11 @@ describe('Test Mode', function() {
             expect(job.data).to.eql({ foo: 'bar' });
         });
 
+        it('returns the Job when saving', function() {
+            var job = queue.createJob('myJob', { foo: 'bar' });
+            var savedJob = job.save();
+            expect(savedJob).to.equal(job);
+        });
 
         describe('#clear', function() {
             it('resets the list of jobs', function() {

--- a/test/test_mode.js
+++ b/test/test_mode.js
@@ -35,8 +35,8 @@ describe('Test Mode', function() {
         it('adds an auto incrementing ID when saving a Job', function() {
           var job = queue.createJob('myJob', { first: true }).save();
           var anotherJob = queue.createJob('myJob', { first: false }).save();
-          expect(job.id).to.be.a('number');
-          expect(anotherJob.id).to.be.a('number');
+          expect(job.id).to.equal(0);
+          expect(anotherJob.id).to.equal(1);
         });
 
         describe('#clear', function() {

--- a/test/test_mode.js
+++ b/test/test_mode.js
@@ -39,6 +39,13 @@ describe('Test Mode', function() {
           expect(anotherJob.id).to.equal(1);
         });
 
+        it('sets the timestamps when saving a Job', function() {
+          var job = queue.createJob('myJob', {}).save();
+          expect(job.created_at).to.exist;
+          expect(job.promote_at).to.exist;
+          expect(job.updated_at).to.exist;
+        });
+
         describe('#clear', function() {
             it('resets the list of jobs', function() {
                 queue.createJob('myJob', { foo: 'bar' }).save();

--- a/test/test_mode.js
+++ b/test/test_mode.js
@@ -32,6 +32,13 @@ describe('Test Mode', function() {
             expect(savedJob).to.equal(job);
         });
 
+        it('adds an auto incrementing ID when saving a Job', function() {
+          var job = queue.createJob('myJob', { first: true }).save();
+          var anotherJob = queue.createJob('myJob', { first: false }).save();
+          expect(job.id).to.be.a('number');
+          expect(anotherJob.id).to.be.a('number');
+        });
+
         describe('#clear', function() {
             it('resets the list of jobs', function() {
                 queue.createJob('myJob', { foo: 'bar' }).save();

--- a/test/test_mode.js
+++ b/test/test_mode.js
@@ -30,6 +30,18 @@ describe('Test Mode', function() {
       });
     });
 
+    describe('#update', function() {
+      it('touches the updated_at timestamps', function(done) {
+        var job = queue.createJob('myJob', {}).save();
+        var oldTimestamp = job.updated_at;
+
+        setTimeout(function () {
+          expect(job.update().updated_at).to.be.greaterThan(oldTimestamp);
+          done();
+        }, 1);
+      });
+    });
+
     describe('#clear', function() {
       it('resets the list of jobs', function() {
         queue.createJob('myJob', { foo: 'bar' }).save();

--- a/test/test_mode.js
+++ b/test/test_mode.js
@@ -28,6 +28,14 @@ describe('Test Mode', function() {
         expect(job.promote_at).to.exist;
         expect(job.updated_at).to.exist;
       });
+
+      it('emits the `enqueue` event', function(done) {
+        var job = queue.createJob('myJob', {});
+        job.on('enqueue', function() {
+          done();
+        });
+        job.save();
+      });
     });
 
     describe('#update', function() {


### PR DESCRIPTION
As outlined in ticket #627 there is some functionality missing in the test mode, which I would love to use for testing :smile: @behrad told me that a PR is welcome, so here is my PR. With this PR the test mode now does the following things (without using Redis):

* Replicate the behavior of save and update more closely (including time stamps)
* Emit the `enqueue`, `failed` and `complete` events from the job and the according events (prefixed with `job `) from the queue.
* Implement `Queue.process` for development mode including a working `done` handler for results and errors.