### PR TITLE
Add support to log objects, errors, arrays, numbers, booleans, etc

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -173,6 +173,14 @@ Job-specific logs enable you to expose information to the UI at any point in the
 job.log('$%d sent to %s', amount, user.name);
 ```
 
+or anything else (uses [util.inspect()](https://nodejs.org/api/util.html#util_util_inspect_object_options) internally):
+
+```js
+job.log({key: 'some key', value: 10});
+job.log({[1,2,3,5,8]});
+job.log(10.1);
+```
+
 ### Job Progress
 
 Job progress is extremely useful for long-running jobs such as video conversion. To update the job's progress simply invoke `job.progress(completed, total [, data])`:

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -317,13 +317,14 @@ Job.prototype.toJSON = function() {
 };
 
 /**
- * Log `str` with sprintf-style variable args.
+ * Log `str` with sprintf-style variable args or anything (objects,arrays,numbers,etc).
  *
  * Examples:
  *
  *    job.log('preparing attachments');
- *    job.log({key: 'some key', value: 10});
  *    job.log('sending email to %s at %s', user.name, user.email);
+ *    job.log({key: 'some key', value: 10});
+ *    job.log([1,2,3]);
  *
  * Specifiers:
  *

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -14,6 +14,7 @@ var EventEmitter = require('events').EventEmitter
   , redis        = require('../redis')
   , reds         = require('reds')
   , _            = require('lodash')
+  , util         = require('util')
   , noop         = function() {
 };
 
@@ -319,6 +320,7 @@ Job.prototype.toJSON = function() {
  * Examples:
  *
  *    job.log('preparing attachments');
+ *    job.log({key: 'some key', value: 10});
  *    job.log('sending email to %s at %s', user.name, user.email);
  *
  * Specifiers:
@@ -336,15 +338,19 @@ Job.prototype.log = function( str ) {
   var args = arguments
     , i    = 1;
 
-  str = str.replace(/%([sd])/g, function( _, type ) {
-    var arg = args[ i++ ];
-    switch(type) {
-      case 'd':
-        return arg | 0;
-      case 's':
-        return arg;
-    }
-  });
+  if(typeof str === 'string') {
+    str = str.replace(/%([sd])/g, function (_, type) {
+      var arg = args[i++];
+      switch (type) {
+        case 'd':
+          return arg | 0;
+        case 's':
+          return arg;
+      }
+    });
+  }else{
+    str = util.inspect(str);
+  }
 
   this.client.rpush(this.client.getKey('job:' + this.id + ':log'), str);
   this.set('updated_at', Date.now());

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -304,6 +304,44 @@ describe 'Kue Tests', ->
         else
           jdone( new Error('reaattempt') )
 
+    it 'should log with a sprintf-style string', (done) ->
+      jobs.create( 'log-job', { title: 'simple job' } ).save()
+      jobs.process 'log-job', (job, jdone) ->
+        job.log('this is %s number %d','test',1)
+        Job.log job.id, (err,logs) ->
+          logs[0].should.be.equal('this is test number 1');
+          done()
+        jdone()
+
+    it 'should log objects, errors, arrays, numbers, etc', (done) ->
+      jobs.create( 'log-job', { title: 'simple job' } ).save()
+      jobs.process 'log-job', (job, jdone) ->
+        job.log()
+        job.log(undefined)
+        job.log(null)
+        job.log({test: 'some text'})
+        job.log(new Error('test error'))
+        job.log([1,2,3])
+        job.log(123)
+        job.log(0)
+        job.log(NaN)
+        job.log(true)
+        job.log(false)
+        Job.log job.id, (err,logs) ->
+          logs[0].should.be.equal('undefined');
+          logs[1].should.be.equal('undefined');
+          logs[2].should.be.equal('null');
+          logs[3].should.be.equal('{ test: \'some text\' }');
+          logs[4].should.be.equal('[Error: test error]');
+          logs[5].should.be.equal('[ 1, 2, 3 ]');
+          logs[6].should.be.equal('123');
+          logs[7].should.be.equal('0');
+          logs[8].should.be.equal('NaN');
+          logs[9].should.be.equal('true');
+          logs[10].should.be.equal('false');
+          done()
+        jdone()
+
 
 
 

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -313,6 +313,8 @@ describe 'Kue Tests', ->
           done()
         jdone()
 
+
+
     it 'should log objects, errors, arrays, numbers, etc', (done) ->
       jobs.create( 'log-job', { title: 'simple job' } ).save()
       jobs.process 'log-job', (job, jdone) ->
@@ -323,6 +325,7 @@ describe 'Kue Tests', ->
         job.log(new Error('test error'))
         job.log([1,2,3])
         job.log(123)
+        job.log(1.23)
         job.log(0)
         job.log(NaN)
         job.log(true)
@@ -335,10 +338,11 @@ describe 'Kue Tests', ->
           logs[4].should.be.equal('[Error: test error]');
           logs[5].should.be.equal('[ 1, 2, 3 ]');
           logs[6].should.be.equal('123');
-          logs[7].should.be.equal('0');
-          logs[8].should.be.equal('NaN');
-          logs[9].should.be.equal('true');
-          logs[10].should.be.equal('false');
+          logs[7].should.be.equal('1.23');
+          logs[8].should.be.equal('0');
+          logs[9].should.be.equal('NaN');
+          logs[10].should.be.equal('true');
+          logs[11].should.be.equal('false');
           done()
         jdone()
 


### PR DESCRIPTION
The current version of kue only support logging strings (with job.log). Sending anything but a string will cause an error.

This pull request add the support to log objects, errors, arrays, numbers, booleans, etc (internally I'm using util.inspect to convert anything to a string). 