### PR TITLE
Support auth specified as username:password

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -29,10 +29,18 @@ exports.configureFactory = function( options, queue ) {
       throw new Error('kue connection string must use the redis: protocol');
     }
 
+    var auth = conn_info.auth;
+    if (auth) {
+      var authParts = auth.split(':');
+      if (authParts.length === 2) {
+        auth = authParts[1];
+      }
+    }
+
     options.redis = {
       port: conn_info.port || 6379,
       host: conn_info.hostname,
-      auth: conn_info.auth,
+      auth: auth,
       // see https://github.com/mranney/node_redis#rediscreateclient
       options: conn_info.query
     };


### PR DESCRIPTION
When using Redis supplied by Heroku, the REDIS_URL env variable is set on the following form:

redis://h:pass@host:port

In Kue this means the auth get set to h:pass, instead of just pass. The attached PR checks for this form, and sets the auth to just the password part.

I am unsure how to properly test this, since it requires a password on the test redis instance.