### PR TITLE
A potential solution for Automattic/kue#620.

### DIFF
--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -17,6 +17,7 @@ var app        = express()
   , provides   = require('./middleware/provides')
   , stylus     = require('stylus')
   , routes     = require('./routes')
+  , jade       = require('jade')
   , json       = require('./routes/json')
   , util       = require('util')
   , nib        = require('nib');
@@ -37,6 +38,7 @@ function compile( str, path ) {
 
 app.set('view options', { doctype: 'html' });
 app.set('view engine', 'jade');
+app.engine('jade', jade.renderFile);
 app.set('views', __dirname + '/views');
 app.set('title', 'Kue');
 app.locals     = { inspect: util.inspect };


### PR DESCRIPTION
An solution for #620.

Simply put, by explicitly referencing the Jade dependency, other projects with both Kue and Express dependencies don't have to explicitly install Jade.