### PR TITLE
Add remove event

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -191,6 +191,7 @@ Job-specific events are fired on the `Job` instances via Redis pubsub. The follo
     - `failed attempt` the job has failed, but has remaining attempts yet
     - `failed` the job has failed and has no remaining attempts
     - `complete` the job has completed
+    - `remove` the job has been removed
 
 
 For example this may look something like the following:

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -585,6 +585,7 @@ Job.prototype.remove = function( fn ) {
     .del(client.getKey('job:' + this.id))
     .exec(function( err ) {
 //            events.remove(this);
+      events.emit(this.id, 'remove', this.type);
       if( !exports.disableSearch ) {
         getSearch().remove(this.id, fn);
       } else {

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -361,3 +361,14 @@ describe 'Kue Tests', ->
       jobs.failed (err, ids) ->
         totalJobs.failed = ids.length
         removeJobById id, 'failed', done for id in ids
+
+
+
+    it 'should receive a job remove event', (done) ->
+      jobs.on 'job remove', (id, type) ->
+        if( type == 'removable-job' )
+          id.should.be.equal( job.id )
+          done()
+      jobs.process 'removable-job', (job, jdone) ->
+        jdone()
+      job = jobs.create('removable-job', {}).save().remove()


### PR DESCRIPTION
![remove job](http://cdn5.howtogeek.com/wp-content/uploads/2013/07/650x300xfinger-pressing-delete-button.jpg.pagespeed.ic.zIJZw9QZeB.jpg)

Sometimes you want to be notified when jobs are removed.  This makes that possible.