### PR TITLE
Added noMoreAttempts method to Job object

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -568,6 +568,16 @@ Job.prototype.searchKeys = function( keys ) {
 };
 
 /**
+ * Cancel job next attempts
+ * @return {Job} for chaining
+ * @api public
+ */
+Job.prototype.noMoreAttempts = function() {
+  this._max_attempts = this._attempts || 1;
+  return this;
+};
+
+/**
  * Remove the job and callback `fn(err)`.
  *
  * @param {Function} fn
@@ -785,6 +795,9 @@ Job.prototype.update = function( fn ) {
 
   // priority
   this.set('priority', this._priority);
+
+  // Max attempts update
+  this.set('max_attempts', this._max_attempts);
 
   this.client.zadd(this.client.getKey('jobs'), this._priority, this.id);
 


### PR DESCRIPTION
Pull request for issue #612 

Allows to end a job processing when there are attempts left. It sets the 'max attempts' value of a job to the current number of attempts, as discussed in the issue.

For this, I had to modify the update method to save the 'max attempts' value.