### PR TITLE
Remove the job type.

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -445,6 +445,19 @@ Queue.prototype.types = function( fn ) {
 };
 
 /**
+ * Remove the job type.
+ *
+ * @param {String} type
+ * @return {Queue} for chaining
+ * @api public
+ */
+
+Queue.prototype.removeType = function( type ) {
+  this.client.srem(this.client.getKey('job:types'), type);
+  return this;
+};
+
+/**
  * Return job ids with the given `state`, and callback `fn(err, ids)`.
  *
  * @param {String} state


### PR DESCRIPTION
This is a feature to delete the job type. 
Such that we can delete the depreciated job type. 
It is good if we want to have a clearly list of job type in kue ui.