### PR TITLE
Adding support for multi-type workers.

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -208,16 +208,17 @@ exports.get = function( id, fn ) {
 };
 
 exports.removeBadJob = function( id ) {
+	var zid = createFIFO(id);
   var client = redis.client();
   client.multi()
     .del(client.getKey('job:' + id + ':log'))
     .del(client.getKey('job:' + id))
-    .zrem(client.getKey('jobs:inactive'), id)
-    .zrem(client.getKey('jobs:active'), id)
-    .zrem(client.getKey('jobs:complete'), id)
-    .zrem(client.getKey('jobs:failed'), id)
-    .zrem(client.getKey('jobs:delayed'), id)
-    .zrem(client.getKey('jobs'), id)
+    .zrem(client.getKey('jobs:inactive'), zid)
+    .zrem(client.getKey('jobs:active'), zid)
+    .zrem(client.getKey('jobs:complete'), zid)
+    .zrem(client.getKey('jobs:failed'), zid)
+    .zrem(client.getKey('jobs:delayed'), zid)
+    .zrem(client.getKey('jobs'), zid)
     .exec();
   if( !exports.disableSearch ) {
     getSearch().remove(id);
@@ -604,9 +605,9 @@ Job.prototype.searchKeys = function( keys ) {
 Job.prototype.remove = function( fn ) {
   var client = this.client;
   client.multi()
-    .zrem(client.getKey('jobs:' + this.state()), this.id)
-    .zrem(client.getKey('jobs:' + this.type + ':' + this.state()), this.id)
-    .zrem(client.getKey('jobs'), this.id)
+    .zrem(client.getKey('jobs:' + this.state()), this.zid)
+    .zrem(client.getKey('jobs:' + this.type + ':' + this.state()), this.zid)
+    .zrem(client.getKey('jobs'), this.zid)
     .del(client.getKey('job:' + this.id + ':log'))
     .del(client.getKey('job:' + this.id))
     .exec(function( err ) {
@@ -637,17 +638,17 @@ Job.prototype.state = function( state, fn ) {
   var multi    = client.multi();
   if( oldState && oldState != '' && oldState != state ) {
     multi
-      .zrem(client.getKey('jobs:' + oldState), this.id)
-      .zrem(client.getKey('jobs:' + this.type + ':' + oldState), this.id);
+      .zrem(client.getKey('jobs:' + oldState), this.zid)
+      .zrem(client.getKey('jobs:' + this.type + ':' + oldState), this.zid);
   }
   multi
     .hset(client.getKey('job:' + this.id), 'state', state)
-    .zadd(client.getKey('jobs:' + state), this._priority, this.id)
-    .zadd(client.getKey('jobs:' + this.type + ':' + state), this._priority, this.id);
+    .zadd(client.getKey('jobs:' + state), this._priority, this.zid)
+    .zadd(client.getKey('jobs:' + this.type + ':' + state), this._priority, this.zid);
 
   // use promote_at as score when job moves to delayed
-  ('delayed' === state) ? multi.zadd(client.getKey('jobs:' + state), parseInt(this.promote_at), this.id) : noop();
-  ('active' === state && this._ttl > 0) ? multi.zadd(client.getKey('jobs:' + state), Date.now() + parseInt(this._ttl), this.id) : noop();
+  ('delayed' === state) ? multi.zadd(client.getKey('jobs:' + state), parseInt(this.promote_at), this.zid) : noop();
+  ('active' === state && this._ttl > 0) ? multi.zadd(client.getKey('jobs:' + state), Date.now() + parseInt(this._ttl), this.zid) : noop();
   ('inactive' === state) ? multi.lpush(client.getKey(this.type + ':jobs'), 1) : noop();
 
   this.set('updated_at', Date.now());
@@ -731,6 +732,13 @@ Job.prototype.delayed = function( clbk ) {
   return this.state('delayed', clbk);
 };
 
+function createFIFO(id) {
+	//Create an id for the zset to preserve FIFO order
+	var idLen = ''+id.toString().length;
+	var len = 3-idLen.length;
+	while(len--) idLen = '0'+idLen;
+	return '('+idLen+')'+id;
+}
 /**
  * Save the job, optionally invoking the callback `fn(err)`.
  *
@@ -751,9 +759,11 @@ Job.prototype.save = function( fn ) {
   // incr id
   client.incr(client.getKey('ids'), function( err, id ) {
     if( err ) return fn(err);
+	
     // add the job for event mapping
     var key = client.getKey('job:' + id);
     self.id = id;
+	self.zid = createFIFO(id);
     self.subscribe(function() {
       self._state     = self._state || (this._delay ? 'delayed' : 'inactive');
       if( max ) client.hset(key, 'max_attempts', max);
@@ -813,7 +823,7 @@ Job.prototype.update = function( fn ) {
   // priority
   this.set('priority', this._priority);
 
-  this.client.zadd(this.client.getKey('jobs'), this._priority, this.id);
+  this.client.zadd(this.client.getKey('jobs'), this._priority, this.zid);
 
   // data
   this.set('data', json, function() {

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -208,17 +208,16 @@ exports.get = function( id, fn ) {
 };
 
 exports.removeBadJob = function( id ) {
-	var zid = createFIFO(id);
   var client = redis.client();
   client.multi()
     .del(client.getKey('job:' + id + ':log'))
     .del(client.getKey('job:' + id))
-    .zrem(client.getKey('jobs:inactive'), zid)
-    .zrem(client.getKey('jobs:active'), zid)
-    .zrem(client.getKey('jobs:complete'), zid)
-    .zrem(client.getKey('jobs:failed'), zid)
-    .zrem(client.getKey('jobs:delayed'), zid)
-    .zrem(client.getKey('jobs'), zid)
+    .zrem(client.getKey('jobs:inactive'), id)
+    .zrem(client.getKey('jobs:active'), id)
+    .zrem(client.getKey('jobs:complete'), id)
+    .zrem(client.getKey('jobs:failed'), id)
+    .zrem(client.getKey('jobs:delayed'), id)
+    .zrem(client.getKey('jobs'), id)
     .exec();
   if( !exports.disableSearch ) {
     getSearch().remove(id);
@@ -605,9 +604,9 @@ Job.prototype.searchKeys = function( keys ) {
 Job.prototype.remove = function( fn ) {
   var client = this.client;
   client.multi()
-    .zrem(client.getKey('jobs:' + this.state()), this.zid)
-    .zrem(client.getKey('jobs:' + this.type + ':' + this.state()), this.zid)
-    .zrem(client.getKey('jobs'), this.zid)
+    .zrem(client.getKey('jobs:' + this.state()), this.id)
+    .zrem(client.getKey('jobs:' + this.type + ':' + this.state()), this.id)
+    .zrem(client.getKey('jobs'), this.id)
     .del(client.getKey('job:' + this.id + ':log'))
     .del(client.getKey('job:' + this.id))
     .exec(function( err ) {
@@ -638,17 +637,17 @@ Job.prototype.state = function( state, fn ) {
   var multi    = client.multi();
   if( oldState && oldState != '' && oldState != state ) {
     multi
-      .zrem(client.getKey('jobs:' + oldState), this.zid)
-      .zrem(client.getKey('jobs:' + this.type + ':' + oldState), this.zid);
+      .zrem(client.getKey('jobs:' + oldState), this.id)
+      .zrem(client.getKey('jobs:' + this.type + ':' + oldState), this.id);
   }
   multi
     .hset(client.getKey('job:' + this.id), 'state', state)
-    .zadd(client.getKey('jobs:' + state), this._priority, this.zid)
-    .zadd(client.getKey('jobs:' + this.type + ':' + state), this._priority, this.zid);
+    .zadd(client.getKey('jobs:' + state), this._priority, this.id)
+    .zadd(client.getKey('jobs:' + this.type + ':' + state), this._priority, this.id);
 
   // use promote_at as score when job moves to delayed
-  ('delayed' === state) ? multi.zadd(client.getKey('jobs:' + state), parseInt(this.promote_at), this.zid) : noop();
-  ('active' === state && this._ttl > 0) ? multi.zadd(client.getKey('jobs:' + state), Date.now() + parseInt(this._ttl), this.zid) : noop();
+  ('delayed' === state) ? multi.zadd(client.getKey('jobs:' + state), parseInt(this.promote_at), this.id) : noop();
+  ('active' === state && this._ttl > 0) ? multi.zadd(client.getKey('jobs:' + state), Date.now() + parseInt(this._ttl), this.id) : noop();
   ('inactive' === state) ? multi.lpush(client.getKey(this.type + ':jobs'), 1) : noop();
 
   this.set('updated_at', Date.now());
@@ -732,13 +731,6 @@ Job.prototype.delayed = function( clbk ) {
   return this.state('delayed', clbk);
 };
 
-function createFIFO(id) {
-	//Create an id for the zset to preserve FIFO order
-	var idLen = ''+id.toString().length;
-	var len = 3-idLen.length;
-	while(len--) idLen = '0'+idLen;
-	return '('+idLen+')'+id;
-}
 /**
  * Save the job, optionally invoking the callback `fn(err)`.
  *
@@ -759,11 +751,9 @@ Job.prototype.save = function( fn ) {
   // incr id
   client.incr(client.getKey('ids'), function( err, id ) {
     if( err ) return fn(err);
-	
     // add the job for event mapping
     var key = client.getKey('job:' + id);
     self.id = id;
-	self.zid = createFIFO(id);
     self.subscribe(function() {
       self._state     = self._state || (this._delay ? 'delayed' : 'inactive');
       if( max ) client.hset(key, 'max_attempts', max);
@@ -823,7 +813,7 @@ Job.prototype.update = function( fn ) {
   // priority
   this.set('priority', this._priority);
 
-  this.client.zadd(this.client.getKey('jobs'), this._priority, this.zid);
+  this.client.zadd(this.client.getKey('jobs'), this._priority, this.id);
 
   // data
   this.set('data', json, function() {

--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -231,6 +231,10 @@ Worker.prototype.process = function( job, fn ) {
   return this;
 };
 
+function parseID(id) {
+	return id.substring(id.indexOf(')')+1);
+}
+
 /**
  * Atomic ZPOP implementation.
  *
@@ -247,7 +251,7 @@ Worker.prototype.zpop = function( key, fn ) {
     .exec(function( err, res ) {
       if( err ) return fn(err);
       var id = res[ 0 ][ 0 ];
-      fn(null, id);
+      fn(null, parseID(id));
     });
 };
 

--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -231,10 +231,6 @@ Worker.prototype.process = function( job, fn ) {
   return this;
 };
 
-function parseID(id) {
-	return id.substring(id.indexOf(')')+1);
-}
-
 /**
  * Atomic ZPOP implementation.
  *
@@ -251,7 +247,7 @@ Worker.prototype.zpop = function( key, fn ) {
     .exec(function( err, res ) {
       if( err ) return fn(err);
       var id = res[ 0 ][ 0 ];
-      fn(null, parseID(id));
+      fn(null, id);
     });
 };
 

--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -264,16 +264,35 @@ Worker.prototype.getJob = function( fn ) {
     return fn("Already Shutdown");
   }
   // alloc a client for this job type
-  var client = clients[ self.type ] || (clients[ self.type ] = redis.createClient());
-  // BLPOP indicates we have a new inactive job to process
-  client.blpop(client.getKey(self.type + ':jobs'), 0, function( err ) {
+  var clientKey = self.type;
+  
+  if( Array.isArray( self.type ) ) {
+    clientKey = self.type.join('-');
+  }
+  
+  var client = clients[ clientKey ] || (clients[ clientKey ] = redis.createClient());
+  
+  var args = [];
+  if( Array.isArray( self.type ) ) {
+	self.type.forEach(function(type){
+	  args.push(client.getKey(type + ':jobs'));
+	})
+  } else {
+	args.push(client.getKey(self.type + ':jobs'));  
+  }
+  args.push(0);
+  args.push(function( err, vals ) {
+	var setName = vals[0];
+	var start = setName.indexOf(':')+1;
+	var end = setName.lastIndexOf(':');
+	var type = setName.substr(start,end-start);
     if( err || !self.running ) {
-      self.client.lpush(self.client.getKey(self.type + ':jobs'), 1);
+      self.client.lpush(self.client.getKey(type + ':jobs'), 1);
       return fn(err);		// SAE: Added to avoid crashing redis on zpop
     }
     // Set job to a temp value so shutdown() knows to wait
     self.job = true;
-    self.zpop(self.client.getKey('jobs:' + self.type + ':inactive'), function( err, id ) {
+    self.zpop(self.client.getKey('jobs:' + type + ':inactive'), function( err, id ) {
       if( err || !id ) {
         self.idle();
         return fn(err /*|| "No job to pop!"*/);
@@ -281,6 +300,9 @@ Worker.prototype.getJob = function( fn ) {
       Job.get(id, fn);
     });
   });
+  
+  // BLPOP indicates we have a new inactive job to process
+  client.blpop.apply(client,args);
 };
 
 /**
@@ -317,10 +339,20 @@ Worker.prototype.shutdown = function( timeout, fn ) {
     self.removeAllListeners();
     self.job        = null;
     //fix half-blob job fetches if any...
-    self.client.lpush(self.client.getKey(self.type + ':jobs'), 1);
+	if ( Array.isArray( self.type ) ) {
+		self.type.forEach(function(type){
+			self.client.lpush(self.client.getKey(type + ':jobs'), 1);
+		});
+	} else {
+		self.client.lpush(self.client.getKey(self.type + ':jobs'), 1);
+	}
     //Safeyly kill any blpop's that are waiting.
-    (self.type in clients) && clients[ self.type ].quit();
-    delete clients[ self.type ];
+	var clientKey = self.type;
+	if( Array.isArray( self.type ) ) {
+	  clientKey = self.type.join('-');
+	}
+    (clientKey in clients) && clients[ clientKey ].quit();
+    delete clients[ clientKey ];
     self.cleaned_up = true;
     fn();
   };


### PR DESCRIPTION
BLPOP is capable of handling multiple queues. So all that is needed to
process multiple queues with one worker is to call queue.process([array
of types],fn).

Kue will then work through the types in the array in order. See BLPOP
for more info.