### PR TITLE
Fixing Job processing order without munging the job IDS

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -656,5 +656,5 @@ Queue.prototype.delayedCount = function( type, fn ) {
 Queue.prototype.testMode = require('./queue/test_mode');
 
 function stripFIFO(id) {
-	return id.substr(id.indexOf(')')+1);
+	return id.substr(id.indexOf('|')+1);
 }

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -187,6 +187,7 @@ Queue.prototype.checkJobPromotion = function( promotionOptions ) {
           //TODO do a ZREMRANGEBYRANK jobs:delayed 0 ids.length-1
           var doUnlock = _.after(ids.length, unlock);
           ids.forEach(function( id ) {
+            id = stripFIFO(id);
             Job.get(id, function( err, job ) {
               if( err ) return doUnlock();
               events.emit(id, 'promotion');
@@ -237,6 +238,7 @@ Queue.prototype.checkActiveJobTtl = function( ttlOptions ) {
 
           var waitForAcks = setTimeout( function(){
             idsRemaining.forEach( function( id ){
+				id = stripFIFO(id);
               Job.get(id, function( err, job ) {
                 if( err ) return doUnlock();
                 job.failedAttempt( { error: true, message: 'TTL exceeded' }, doUnlock );
@@ -245,6 +247,7 @@ Queue.prototype.checkActiveJobTtl = function( ttlOptions ) {
           }, 1000 );
 
           ids.forEach(function( id ) {
+			  id = stripFIFO(id);
             events.emit(id, 'ttl exceeded');
           });
         });
@@ -454,7 +457,13 @@ Queue.prototype.types = function( fn ) {
  */
 
 Queue.prototype.state = function( state, fn ) {
-  this.client.zrange(this.client.getKey('jobs:' + state), 0, -1, fn);
+  this.client.zrange(this.client.getKey('jobs:' + state), 0, -1, function(err,ids){
+	  var fixedIds = [];
+	  ids.forEach(function(id){
+		  fixedIds.push(stripFIFO(id));
+	  });
+	  fn(err,fixedIds);
+  });
   return this;
 };
 
@@ -645,3 +654,7 @@ Queue.prototype.delayedCount = function( type, fn ) {
  */
 
 Queue.prototype.testMode = require('./queue/test_mode');
+
+function stripFIFO(id) {
+	return id.substr(id.indexOf(')')+1);
+}

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -187,7 +187,7 @@ Queue.prototype.checkJobPromotion = function( promotionOptions ) {
           //TODO do a ZREMRANGEBYRANK jobs:delayed 0 ids.length-1
           var doUnlock = _.after(ids.length, unlock);
           ids.forEach(function( id ) {
-            id = stripFIFO(id);
+            id = client.stripFIFO(id);
             Job.get(id, function( err, job ) {
               if( err ) return doUnlock();
               events.emit(id, 'promotion');
@@ -238,7 +238,7 @@ Queue.prototype.checkActiveJobTtl = function( ttlOptions ) {
 
           var waitForAcks = setTimeout( function(){
             idsRemaining.forEach( function( id ){
-				id = stripFIFO(id);
+				id = client.stripFIFO(id);
               Job.get(id, function( err, job ) {
                 if( err ) return doUnlock();
                 job.failedAttempt( { error: true, message: 'TTL exceeded' }, doUnlock );
@@ -247,7 +247,7 @@ Queue.prototype.checkActiveJobTtl = function( ttlOptions ) {
           }, 1000 );
 
           ids.forEach(function( id ) {
-			  id = stripFIFO(id);
+			  id = client.stripFIFO(id);
             events.emit(id, 'ttl exceeded');
           });
         });
@@ -457,10 +457,11 @@ Queue.prototype.types = function( fn ) {
  */
 
 Queue.prototype.state = function( state, fn ) {
+  var self = this;
   this.client.zrange(this.client.getKey('jobs:' + state), 0, -1, function(err,ids){
 	  var fixedIds = [];
 	  ids.forEach(function(id){
-		  fixedIds.push(stripFIFO(id));
+		  fixedIds.push(self.client.stripFIFO(id));
 	  });
 	  fn(err,fixedIds);
   });
@@ -654,7 +655,3 @@ Queue.prototype.delayedCount = function( type, fn ) {
  */
 
 Queue.prototype.testMode = require('./queue/test_mode');
-
-function stripFIFO(id) {
-	return id.substr(id.indexOf('|')+1);
-}

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -238,7 +238,7 @@ Queue.prototype.checkActiveJobTtl = function( ttlOptions ) {
 
           var waitForAcks = setTimeout( function(){
             idsRemaining.forEach( function( id ){
-				id = client.stripFIFO(id);
+              id = client.stripFIFO(id);
               Job.get(id, function( err, job ) {
                 if( err ) return doUnlock();
                 job.failedAttempt( { error: true, message: 'TTL exceeded' }, doUnlock );
@@ -247,7 +247,7 @@ Queue.prototype.checkActiveJobTtl = function( ttlOptions ) {
           }, 1000 );
 
           ids.forEach(function( id ) {
-			  id = client.stripFIFO(id);
+            id = client.stripFIFO(id);
             events.emit(id, 'ttl exceeded');
           });
         });
@@ -459,11 +459,11 @@ Queue.prototype.types = function( fn ) {
 Queue.prototype.state = function( state, fn ) {
   var self = this;
   this.client.zrange(this.client.getKey('jobs:' + state), 0, -1, function(err,ids){
-	  var fixedIds = [];
-	  ids.forEach(function(id){
-		  fixedIds.push(self.client.stripFIFO(id));
-	  });
-	  fn(err,fixedIds);
+    var fixedIds = [];
+    ids.forEach(function(id){
+      fixedIds.push(self.client.stripFIFO(id));
+    });
+    fn(err,fixedIds);
   });
   return this;
 };

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -80,6 +80,7 @@ function map( jobs, ids ) {
  */
 
 function get( fn, order ) {
+	var client = redis.client();
   return function( err, ids ) {
     if( err ) return fn(err);
     var pending = ids.length
@@ -87,12 +88,12 @@ function get( fn, order ) {
     if( !pending ) return fn(null, ids);
     ids.forEach(function( id ) {
 		// Turn zid back into regular jobid
-		id = id.substr(id.indexOf(')')+1);
+		id = client.stripFIFO(id);
       exports.get(id, function( err, job ) {
         if( err ) {
           console.error(err);
         } else {
-          jobs[ createFIFO(job.id) ] = job;
+          jobs[ client.createFIFO(job.id) ] = job;
         }
         --pending || fn(null, 'desc' == order
           ? map(jobs, ids).reverse()
@@ -164,7 +165,7 @@ exports.get = function( id, fn ) {
     , job    = new Job;
 
   job.id = id;
-  job.zid = createFIFO(id);
+  job.zid = client.createFIFO(id);
   client.hgetall(client.getKey('job:' + job.id), function( err, hash ) {
     if( err ) return fn(err);
     if( !hash ) {
@@ -211,8 +212,8 @@ exports.get = function( id, fn ) {
 };
 
 exports.removeBadJob = function( id ) {
-	var zid = createFIFO(id);
   var client = redis.client();
+  var zid = client.createFIFO(id);
   client.multi()
     .del(client.getKey('job:' + id + ':log'))
     .del(client.getKey('job:' + id))
@@ -735,13 +736,6 @@ Job.prototype.delayed = function( clbk ) {
   return this.state('delayed', clbk);
 };
 
-function createFIFO(id) {
-	//Create an id for the zset to preserve FIFO order
-	var idLen = ''+id.toString().length;
-	var len = 2-idLen.length;
-	while(len--) idLen = '0'+idLen;
-	return idLen+'|'+id;
-}
 /**
  * Save the job, optionally invoking the callback `fn(err)`.
  *
@@ -766,7 +760,7 @@ Job.prototype.save = function( fn ) {
     // add the job for event mapping
     var key = client.getKey('job:' + id);
     self.id = id;
-	self.zid = createFIFO(id);
+	self.zid = client.createFIFO(id);
     self.subscribe(function() {
       self._state     = self._state || (this._delay ? 'delayed' : 'inactive');
       if( max ) client.hset(key, 'max_attempts', max);

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -80,15 +80,15 @@ function map( jobs, ids ) {
  */
 
 function get( fn, order ) {
-	var client = redis.client();
+  var client = redis.client();
   return function( err, ids ) {
     if( err ) return fn(err);
     var pending = ids.length
       , jobs    = {};
     if( !pending ) return fn(null, ids);
     ids.forEach(function( id ) {
-		// Turn zid back into regular jobid
-		id = client.stripFIFO(id);
+      // Turn zid back into regular jobid
+      id = client.stripFIFO(id);
       exports.get(id, function( err, job ) {
         if( err ) {
           console.error(err);
@@ -756,11 +756,10 @@ Job.prototype.save = function( fn ) {
   // incr id
   client.incr(client.getKey('ids'), function( err, id ) {
     if( err ) return fn(err);
-	
     // add the job for event mapping
     var key = client.getKey('job:' + id);
     self.id = id;
-	self.zid = client.createFIFO(id);
+    self.zid = client.createFIFO(id);
     self.subscribe(function() {
       self._state     = self._state || (this._delay ? 'delayed' : 'inactive');
       if( max ) client.hset(key, 'max_attempts', max);

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -86,11 +86,13 @@ function get( fn, order ) {
       , jobs    = {};
     if( !pending ) return fn(null, ids);
     ids.forEach(function( id ) {
+		// Turn zid back into regular jobid
+		id = id.substr(id.indexOf(')')+1);
       exports.get(id, function( err, job ) {
         if( err ) {
           console.error(err);
         } else {
-          jobs[ job.id ] = job;
+          jobs[ createFIFO(job.id) ] = job;
         }
         --pending || fn(null, 'desc' == order
           ? map(jobs, ids).reverse()
@@ -162,6 +164,7 @@ exports.get = function( id, fn ) {
     , job    = new Job;
 
   job.id = id;
+  job.zid = createFIFO(id);
   client.hgetall(client.getKey('job:' + job.id), function( err, hash ) {
     if( err ) return fn(err);
     if( !hash ) {

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -208,16 +208,17 @@ exports.get = function( id, fn ) {
 };
 
 exports.removeBadJob = function( id ) {
+	var zid = createFIFO(id);
   var client = redis.client();
   client.multi()
     .del(client.getKey('job:' + id + ':log'))
     .del(client.getKey('job:' + id))
-    .zrem(client.getKey('jobs:inactive'), id)
-    .zrem(client.getKey('jobs:active'), id)
-    .zrem(client.getKey('jobs:complete'), id)
-    .zrem(client.getKey('jobs:failed'), id)
-    .zrem(client.getKey('jobs:delayed'), id)
-    .zrem(client.getKey('jobs'), id)
+    .zrem(client.getKey('jobs:inactive'), zid)
+    .zrem(client.getKey('jobs:active'), zid)
+    .zrem(client.getKey('jobs:complete'), zid)
+    .zrem(client.getKey('jobs:failed'), zid)
+    .zrem(client.getKey('jobs:delayed'), zid)
+    .zrem(client.getKey('jobs'), zid)
     .exec();
   if( !exports.disableSearch ) {
     getSearch().remove(id);
@@ -604,9 +605,9 @@ Job.prototype.searchKeys = function( keys ) {
 Job.prototype.remove = function( fn ) {
   var client = this.client;
   client.multi()
-    .zrem(client.getKey('jobs:' + this.state()), this.id)
-    .zrem(client.getKey('jobs:' + this.type + ':' + this.state()), this.id)
-    .zrem(client.getKey('jobs'), this.id)
+    .zrem(client.getKey('jobs:' + this.state()), this.zid)
+    .zrem(client.getKey('jobs:' + this.type + ':' + this.state()), this.zid)
+    .zrem(client.getKey('jobs'), this.zid)
     .del(client.getKey('job:' + this.id + ':log'))
     .del(client.getKey('job:' + this.id))
     .exec(function( err ) {
@@ -637,17 +638,17 @@ Job.prototype.state = function( state, fn ) {
   var multi    = client.multi();
   if( oldState && oldState != '' && oldState != state ) {
     multi
-      .zrem(client.getKey('jobs:' + oldState), this.id)
-      .zrem(client.getKey('jobs:' + this.type + ':' + oldState), this.id);
+      .zrem(client.getKey('jobs:' + oldState), this.zid)
+      .zrem(client.getKey('jobs:' + this.type + ':' + oldState), this.zid);
   }
   multi
     .hset(client.getKey('job:' + this.id), 'state', state)
-    .zadd(client.getKey('jobs:' + state), this._priority, this.id)
-    .zadd(client.getKey('jobs:' + this.type + ':' + state), this._priority, this.id);
+    .zadd(client.getKey('jobs:' + state), this._priority, this.zid)
+    .zadd(client.getKey('jobs:' + this.type + ':' + state), this._priority, this.zid);
 
   // use promote_at as score when job moves to delayed
-  ('delayed' === state) ? multi.zadd(client.getKey('jobs:' + state), parseInt(this.promote_at), this.id) : noop();
-  ('active' === state && this._ttl > 0) ? multi.zadd(client.getKey('jobs:' + state), Date.now() + parseInt(this._ttl), this.id) : noop();
+  ('delayed' === state) ? multi.zadd(client.getKey('jobs:' + state), parseInt(this.promote_at), this.zid) : noop();
+  ('active' === state && this._ttl > 0) ? multi.zadd(client.getKey('jobs:' + state), Date.now() + parseInt(this._ttl), this.zid) : noop();
   ('inactive' === state) ? multi.lpush(client.getKey(this.type + ':jobs'), 1) : noop();
 
   this.set('updated_at', Date.now());
@@ -731,6 +732,13 @@ Job.prototype.delayed = function( clbk ) {
   return this.state('delayed', clbk);
 };
 
+function createFIFO(id) {
+	//Create an id for the zset to preserve FIFO order
+	var idLen = ''+id.toString().length;
+	var len = 3-idLen.length;
+	while(len--) idLen = '0'+idLen;
+	return '('+idLen+')'+id;
+}
 /**
  * Save the job, optionally invoking the callback `fn(err)`.
  *
@@ -751,9 +759,11 @@ Job.prototype.save = function( fn ) {
   // incr id
   client.incr(client.getKey('ids'), function( err, id ) {
     if( err ) return fn(err);
+	
     // add the job for event mapping
     var key = client.getKey('job:' + id);
     self.id = id;
+	self.zid = createFIFO(id);
     self.subscribe(function() {
       self._state     = self._state || (this._delay ? 'delayed' : 'inactive');
       if( max ) client.hset(key, 'max_attempts', max);
@@ -813,7 +823,7 @@ Job.prototype.update = function( fn ) {
   // priority
   this.set('priority', this._priority);
 
-  this.client.zadd(this.client.getKey('jobs'), this._priority, this.id);
+  this.client.zadd(this.client.getKey('jobs'), this._priority, this.zid);
 
   // data
   this.set('data', json, function() {

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -738,9 +738,9 @@ Job.prototype.delayed = function( clbk ) {
 function createFIFO(id) {
 	//Create an id for the zset to preserve FIFO order
 	var idLen = ''+id.toString().length;
-	var len = 3-idLen.length;
+	var len = 2-idLen.length;
 	while(len--) idLen = '0'+idLen;
-	return '('+idLen+')'+id;
+	return idLen+'|'+id;
 }
 /**
  * Save the job, optionally invoking the callback `fn(err)`.

--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -231,9 +231,6 @@ Worker.prototype.process = function( job, fn ) {
   return this;
 };
 
-function stripFIFO(id) {
-	return id.substring(id.indexOf('|')+1);
-}
 
 /**
  * Atomic ZPOP implementation.
@@ -244,6 +241,8 @@ function stripFIFO(id) {
  */
 
 Worker.prototype.zpop = function( key, fn ) {
+  // get client
+  var client = clients[ this.type ] || (clients[ this.type ] = redis.createClient());
   this.client
     .multi()
     .zrange(key, 0, 0)
@@ -251,7 +250,7 @@ Worker.prototype.zpop = function( key, fn ) {
     .exec(function( err, res ) {
       if( err ) return fn(err);
       var id = res[ 0 ][ 0 ];
-      fn(null, stripFIFO(id));
+      fn(null, client.stripFIFO(id));
     });
 };
 

--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -231,6 +231,10 @@ Worker.prototype.process = function( job, fn ) {
   return this;
 };
 
+function parseID(id) {
+	return id.substring(id.indexOf(')')+1);
+}
+
 /**
  * Atomic ZPOP implementation.
  *
@@ -247,7 +251,7 @@ Worker.prototype.zpop = function( key, fn ) {
     .exec(function( err, res ) {
       if( err ) return fn(err);
       var id = res[ 0 ][ 0 ];
-      fn(null, id);
+      fn(null, parseID(id));
     });
 };
 

--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -231,8 +231,8 @@ Worker.prototype.process = function( job, fn ) {
   return this;
 };
 
-function parseID(id) {
-	return id.substring(id.indexOf(')')+1);
+function stripFIFO(id) {
+	return id.substring(id.indexOf('|')+1);
 }
 
 /**
@@ -251,7 +251,7 @@ Worker.prototype.zpop = function( key, fn ) {
     .exec(function( err, res ) {
       if( err ) return fn(err);
       var id = res[ 0 ][ 0 ];
-      fn(null, parseID(id));
+      fn(null, stripFIFO(id));
     });
 };
 

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -67,6 +67,17 @@ exports.configureFactory = function( options, queue ) {
     client.getKey = function( key ) {
       return this.prefix + ':' + key;
     };
+	client.createFIFO = function( id ) {
+		//Create an id for the zset to preserve FIFO order
+		var idLen = ''+id.toString().length;
+		var len = 2-idLen.length;
+		while(len--) idLen = '0'+idLen;
+		return idLen+'|'+id;
+	}
+	// Parse out original ID from zid
+	client.stripFIFO = function( zid ) {
+		return zid.substr(zid.indexOf('|')+1);
+	}
     return client;
   };
 };

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -76,7 +76,13 @@ exports.configureFactory = function( options, queue ) {
     }
     // Parse out original ID from zid
     client.stripFIFO = function( zid ) {
-      return zid.substr(zid.indexOf('|')+1);
+      // Sometimes this gets called with an undefined
+      // it seems to be OK to have that not resolve to an id
+      if ( typeof zid === 'string' ) {
+        return zid.substr(zid.indexOf('|')+1);
+      } else {
+        return null;
+      }
     }
     return client;
   };

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -67,17 +67,17 @@ exports.configureFactory = function( options, queue ) {
     client.getKey = function( key ) {
       return this.prefix + ':' + key;
     };
-	client.createFIFO = function( id ) {
-		//Create an id for the zset to preserve FIFO order
-		var idLen = ''+id.toString().length;
-		var len = 2-idLen.length;
-		while(len--) idLen = '0'+idLen;
-		return idLen+'|'+id;
-	}
-	// Parse out original ID from zid
-	client.stripFIFO = function( zid ) {
-		return zid.substr(zid.indexOf('|')+1);
-	}
+    client.createFIFO = function( id ) {
+      //Create an id for the zset to preserve FIFO order
+      var idLen = ''+id.toString().length;
+      var len = 2-idLen.length;
+      while(len--) idLen = '0'+idLen;
+      return idLen+'|'+id;
+    }
+    // Parse out original ID from zid
+    client.stripFIFO = function( zid ) {
+      return zid.substr(zid.indexOf('|')+1);
+    }
     return client;
   };
 };


### PR DESCRIPTION
This is my attempt at fixing the FIFO issue.

I created an internal zid value that is used for zsets. This string value is in form: (id.length)id.

This allows for the ID to be parsed back out while maintaining the job order.

The length portion is fixed at 3 characters, which allow for ids to stay in order up to 999 digits long. This seemed sufficient to me, but is an upper limit. This could be easily increased if there is a need.