### PR TITLE
Adding support for multi-type workers.

### DIFF
--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -274,18 +274,18 @@ Worker.prototype.getJob = function( fn ) {
   
   var args = [];
   if( Array.isArray( self.type ) ) {
-	self.type.forEach(function(type){
-	  args.push(client.getKey(type + ':jobs'));
-	})
+  self.type.forEach(function(type){
+    args.push(client.getKey(type + ':jobs'));
+  })
   } else {
-	args.push(client.getKey(self.type + ':jobs'));  
+    args.push(client.getKey(self.type + ':jobs'));  
   }
   args.push(0);
   args.push(function( err, vals ) {
-	var setName = vals[0];
-	var start = setName.indexOf(':')+1;
-	var end = setName.lastIndexOf(':');
-	var type = setName.substr(start,end-start);
+    var setName = vals[0];
+    var start = setName.indexOf(':')+1;
+    var end = setName.lastIndexOf(':');
+    var type = setName.substr(start,end-start);
     if( err || !self.running ) {
       self.client.lpush(self.client.getKey(type + ':jobs'), 1);
       return fn(err);		// SAE: Added to avoid crashing redis on zpop
@@ -339,18 +339,18 @@ Worker.prototype.shutdown = function( timeout, fn ) {
     self.removeAllListeners();
     self.job        = null;
     //fix half-blob job fetches if any...
-	if ( Array.isArray( self.type ) ) {
-		self.type.forEach(function(type){
-			self.client.lpush(self.client.getKey(type + ':jobs'), 1);
-		});
-	} else {
-		self.client.lpush(self.client.getKey(self.type + ':jobs'), 1);
-	}
+    if ( Array.isArray( self.type ) ) {
+      self.type.forEach(function(type){
+        self.client.lpush(self.client.getKey(type + ':jobs'), 1);
+      });
+    } else {
+      self.client.lpush(self.client.getKey(self.type + ':jobs'), 1);
+    }
     //Safeyly kill any blpop's that are waiting.
-	var clientKey = self.type;
-	if( Array.isArray( self.type ) ) {
-	  clientKey = self.type.join('-');
-	}
+    var clientKey = self.type;
+    if( Array.isArray( self.type ) ) {
+      clientKey = self.type.join('-');
+    }
     (clientKey in clients) && clients[ clientKey ].quit();
     delete clients[ clientKey ];
     self.cleaned_up = true;

--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -264,16 +264,35 @@ Worker.prototype.getJob = function( fn ) {
     return fn("Already Shutdown");
   }
   // alloc a client for this job type
-  var client = clients[ self.type ] || (clients[ self.type ] = redis.createClient());
-  // BLPOP indicates we have a new inactive job to process
-  client.blpop(client.getKey(self.type + ':jobs'), 0, function( err ) {
+  var clientKey = self.type;
+  
+  if( Array.isArray( self.type ) ) {
+    clientKey = self.type.join('-');
+  }
+  
+  var client = clients[ clientKey ] || (clients[ clientKey ] = redis.createClient());
+  
+  var args = [];
+  if( Array.isArray( self.type ) ) {
+	self.type.forEach(function(type){
+	  args.push(client.getKey(type + ':jobs'));
+	})
+  } else {
+	args.push(client.getKey(self.type + ':jobs'));  
+  }
+  args.push(0);
+  args.push(function( err, vals ) {
+	var setName = vals[0];
+	var start = setName.indexOf(':')+1;
+	var end = setName.lastIndexOf(':');
+	var type = setName.substr(start,end-start);
     if( err || !self.running ) {
-      self.client.lpush(self.client.getKey(self.type + ':jobs'), 1);
+      self.client.lpush(self.client.getKey(type + ':jobs'), 1);
       return fn(err);		// SAE: Added to avoid crashing redis on zpop
     }
     // Set job to a temp value so shutdown() knows to wait
     self.job = true;
-    self.zpop(self.client.getKey('jobs:' + self.type + ':inactive'), function( err, id ) {
+    self.zpop(self.client.getKey('jobs:' + type + ':inactive'), function( err, id ) {
       if( err || !id ) {
         self.idle();
         return fn(err /*|| "No job to pop!"*/);
@@ -281,6 +300,9 @@ Worker.prototype.getJob = function( fn ) {
       Job.get(id, fn);
     });
   });
+  
+  // BLPOP indicates we have a new inactive job to process
+  client.blpop.apply(client,args);
 };
 
 /**
@@ -317,10 +339,20 @@ Worker.prototype.shutdown = function( timeout, fn ) {
     self.removeAllListeners();
     self.job        = null;
     //fix half-blob job fetches if any...
-    self.client.lpush(self.client.getKey(self.type + ':jobs'), 1);
+	if ( Array.isArray( self.type ) ) {
+		self.type.forEach(function(type){
+			self.client.lpush(self.client.getKey(type + ':jobs'), 1);
+		});
+	} else {
+		self.client.lpush(self.client.getKey(self.type + ':jobs'), 1);
+	}
     //Safeyly kill any blpop's that are waiting.
-    (self.type in clients) && clients[ self.type ].quit();
-    delete clients[ self.type ];
+	var clientKey = self.type;
+	if( Array.isArray( self.type ) ) {
+	  clientKey = self.type.join('-');
+	}
+    (clientKey in clients) && clients[ clientKey ].quit();
+    delete clients[ clientKey ];
     self.cleaned_up = true;
     fn();
   };


### PR DESCRIPTION
BLPOP is capable of handling multiple queues. So all that is needed to
process multiple queues with one worker is to call queue.process([array
of types],fn).

Kue will then work through the types in the array in order. See BLPOP
for more info.