### PR TITLE
removeBadJob will cleanup keys in jobs:TYPE:STATE

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -75,18 +75,19 @@ function map( jobs, ids ) {
  *
  * @param {Function} fn
  * @param {String} order
+ * @param {String} jobType
  * @return {Function}
  * @api private
  */
 
-function get( fn, order ) {
+function get( fn, order, jobType) {
   return function( err, ids ) {
     if( err ) return fn(err);
     var pending = ids.length
       , jobs    = {};
     if( !pending ) return fn(null, ids);
     ids.forEach(function( id ) {
-      exports.get(id, function( err, job ) {
+      exports.get(id, jobType, function( err, job ) {
         if( err ) {
           console.error(err);
         } else {
@@ -146,18 +147,20 @@ exports.rangeByState = function( state, from, to, order, fn ) {
  */
 
 exports.rangeByType = function( type, state, from, to, order, fn ) {
-  redis.client().zrange(redis.client().getKey('jobs:' + type + ':' + state), from, to, get(fn, order));
+  redis.client().zrange(redis.client().getKey('jobs:' + type + ':' + state), from, to, get(fn, order, type));
 };
 
 /**
  * Get job with `id` and callback `fn(err, job)`.
  *
  * @param {Number} id
+ * @param {String} jobType is optional
  * @param {Function} fn
  * @api public
  */
 
-exports.get = function( id, fn ) {
+exports.get = function( id, jobType, fn ) {
+  if (typeof jobType === 'function' && !fn) fn = jobType;
   var client = redis.client()
     , job    = new Job;
 
@@ -165,11 +168,11 @@ exports.get = function( id, fn ) {
   client.hgetall(client.getKey('job:' + job.id), function( err, hash ) {
     if( err ) return fn(err);
     if( !hash ) {
-      exports.removeBadJob(job.id);
+      exports.removeBadJob(job.id, jobType);
       return fn(new Error('job "' + job.id + '" doesnt exist'));
     }
     if( !hash.type ) {
-      exports.removeBadJob(job.id);
+      exports.removeBadJob(job.id, jobType);
       return fn(new Error('job "' + job.id + '" is invalid'))
     }
     // TODO: really lame, change some methods so
@@ -207,7 +210,15 @@ exports.get = function( id, fn ) {
   });
 };
 
-exports.removeBadJob = function( id ) {
+/**
+ * Remove all references to an invalid job. Will remove leaky keys in redis keys:TYPE:STATE when
+ * exports.rangeByType is used.
+ *
+ * @param {Number} id
+ * @param {String} jobType
+ */
+
+exports.removeBadJob = function( id, jobType) {
   var client = redis.client();
   client.multi()
     .del(client.getKey('job:' + id + ':log'))
@@ -218,6 +229,11 @@ exports.removeBadJob = function( id ) {
     .zrem(client.getKey('jobs:failed'), id)
     .zrem(client.getKey('jobs:delayed'), id)
     .zrem(client.getKey('jobs'), id)
+    .zrem(client.getKey('jobs:' + jobType + ':inactive'), id)
+    .zrem(client.getKey('jobs:' + jobType+ ':active'), id)
+    .zrem(client.getKey('jobs:' + jobType + ':complete'), id)
+    .zrem(client.getKey('jobs:' + jobType + ':failed'), id)
+    .zrem(client.getKey('jobs:' + jobType + ':delayed'), id)
     .exec();
   if( !exports.disableSearch ) {
     getSearch().remove(id);

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -160,7 +160,10 @@ exports.rangeByType = function( type, state, from, to, order, fn ) {
  */
 
 exports.get = function( id, jobType, fn ) {
-  if (typeof jobType === 'function' && !fn) fn = jobType;
+  if (typeof jobType === 'function' && !fn) {
+    fn = jobType;
+    jobType = '';
+  }
   var client = redis.client()
     , job    = new Job;
 


### PR DESCRIPTION
Still don't know why some jobs leak keys, but this PR will cleanup the leaky redis keys when using `kue.Job.rangeByType`

https://github.com/Automattic/kue/issues/706
https://github.com/Automattic/kue/issues/430