### PR TITLE
Fix redirection issue when app context has a trailing '/'

### DIFF
--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -68,6 +68,12 @@ app.post('/job', provides('json'), bodyParser.json(), json.createJob);
 
 app.get('/', function( req, res ) {
   var context = app.mountpath || req.baseUrl;
+
+  // Strip trailing slash from context
+  if( context && context[context.length - 1] === '/' ) {
+    context = context.substring(0, context.length - 1);
+  }
+
   res.redirect(context + '/active');
 });
 


### PR DESCRIPTION
If the `app.mountpath` is just `/`, then the redirection ends up being `//active` which is invalid.

This change checks the `context` for a trailing slash, and removes it if it exists.