### PR TITLE
Update dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ test-bdd-coffee:
     --compilers coffee:coffee-script \
     --reporter $(REPORTER) \
     --require should \
+    --require coffee-script/register \
     --ui bdd \
     test/*.coffee
 

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -377,8 +377,8 @@ Queue.prototype.shutdown = function( timeout, type, fn ) {
 
   var cleanup = function() {
     if( self.shuttingDown ) {
-      self.client && self.client.end();
-      self.lockClient && self.lockClient.end();
+      self.client && self.client.quit();
+      self.lockClient && self.lockClient.quit();
       self.client     = null;
       self.workers    = [];
       exports.workers = [];

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lodash-deep": "^1.1.0",
     "nib": "~1.1.0",
     "node-redis-warlock": "^0.1.2",
-    "redis": "^1.0.0",
+    "redis": "^2.3.0",
     "reds": "~0.2.5",
     "stylus": "~0.52.4"
   },

--- a/package.json
+++ b/package.json
@@ -28,21 +28,21 @@
     "body-parser": "^1.12.2",
     "express": "^4.12.2",
     "jade": "^1.11.0",
-    "lodash": "^2.4.1",
+    "lodash": "^3.10.1",
     "lodash-deep": "^1.1.0",
-    "nib": "0.5.0",
+    "nib": "~1.1.0",
     "node-redis-warlock": "^0.1.2",
-    "redis": "~0.12.0",
+    "redis": "^1.0.0",
     "reds": "~0.2.5",
-    "stylus": "0.42.2"
+    "stylus": "~0.52.4"
   },
   "devDependencies": {
-    "async": "^0.9.0",
-    "chai": "^2.1.2",
-    "coffee-script": "~1.6.3",
-    "mocha": "~1.17.0",
-    "should": "~3.0.1",
-    "supertest": "~0.15.0"
+    "async": "^1.4.2",
+    "chai": "^3.3.0",
+    "coffee-script": "~1.10.0",
+    "mocha": "^2.3.3",
+    "should": "^3.1.0",
+    "supertest": "~1.1.0"
   },
   "main": "index",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -14,8 +14,8 @@ describe('CONNECTION', function(){
 		  redis: 'redis://localhost:6379/15?foo=bar'
 	  } );
 
-	  jobs.client.connectionOption.port.should.be.eql( 6379 );
-	  jobs.client.connectionOption.host.should.be.eql( 'localhost' );
+	  jobs.client.connection_option.port.should.be.eql( 6379 );
+	  jobs.client.connection_option.host.should.be.eql( 'localhost' );
 	  jobs.client.options.foo.should.be.eql( 'bar' );
 
 	  var jobData = {
@@ -46,8 +46,8 @@ describe('CONNECTION', function(){
 			}
 		} );
 
-		jobs.client.connectionOption.port.should.be.eql( 6379 );
-		jobs.client.connectionOption.host.should.be.eql( 'localhost' );
+		jobs.client.connection_option.port.should.be.eql( 6379 );
+		jobs.client.connection_option.host.should.be.eql( 'localhost' );
 		jobs.client.options.foo.should.be.eql( 'bar' );
 
 		var jobData = {
@@ -71,8 +71,8 @@ describe('CONNECTION', function(){
 			redis: 'redis://localhost:6379/?foo=bar'
 		} );
 
-		jobs.client.connectionOption.port.should.be.eql( 6379 );
-		jobs.client.connectionOption.host.should.be.eql( 'localhost' );
+		jobs.client.connection_option.port.should.be.eql( 6379 );
+		jobs.client.connection_option.host.should.be.eql( 'localhost' );
 		jobs.client.options.foo.should.be.eql( 'bar' );
 
 		var jobData = {
@@ -96,8 +96,8 @@ describe('CONNECTION', function(){
 			redis: 'redis://localhost:6379?foo=bar'
 		} );
 
-		jobs.client.connectionOption.port.should.be.eql( 6379 );
-		jobs.client.connectionOption.host.should.be.eql( 'localhost' );
+		jobs.client.connection_option.port.should.be.eql( 6379 );
+		jobs.client.connection_option.host.should.be.eql( 'localhost' );
 		jobs.client.options.foo.should.be.eql( 'bar' );
 
 		var jobData = {
@@ -127,8 +127,8 @@ describe('CONNECTION', function(){
 			}
 		} );
 
-		jobs.client.connectionOption.port.should.be.eql( 6379 );
-		jobs.client.connectionOption.host.should.be.eql( 'localhost' );
+		jobs.client.connection_option.port.should.be.eql( 6379 );
+		jobs.client.connection_option.host.should.be.eql( 'localhost' );
 		jobs.client.options.foo.should.be.eql( 'bar' );
 
 		var jobData = {
@@ -206,8 +206,8 @@ describe( 'JOBS', function () {
       redis: 'redis://localhost:6379/?foo=bar'
     } );
 
-    jobs.client.connectionOption.port.should.be.eql( 6379 );
-    jobs.client.connectionOption.host.should.be.eql( 'localhost' );
+    jobs.client.connection_option.port.should.be.eql( 6379 );
+    jobs.client.connection_option.host.should.be.eql( 'localhost' );
     jobs.client.options.foo.should.be.eql( 'bar' );
 
     var jobData = {


### PR DESCRIPTION
The dependencies were really old, so I thought I'll update them even though my main concern was just node-redis.

There are still two dependencies that have to be updated because they have breaking changes. Both are probably good for this library.

One is should that will throw on `'42' === 42` from version 4.x.x on and the other one is node-redis 2.0. In both cases the tests won't pass anymore. In some tests there are strings returned instead of numbers, so should breaks. And some other tests fail with node-redis 2.0, since it'll return errors that were earlier suppressed (`Uncaught Error: LPUSH can't be processed. The connection has already been closed.`).

So I highly recommend to check if everything is working as it should.

I'm not even sure if everything works with the dependencies as I updated them, but at least the tests pass. I'm not sure what's with the build and test-tdd tasks in the Makefile btw.