### PR TITLE
use node's util#format()

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -14,6 +14,7 @@ var EventEmitter = require('events').EventEmitter
   , redis        = require('../redis')
   , reds         = require('reds')
   , _            = require('lodash')
+  , util         = require('util')
   , noop         = function() {
 };
 
@@ -334,21 +335,9 @@ Job.prototype.toJSON = function() {
  * @api public
  */
 
-Job.prototype.log = function( str ) {
-  var args = arguments
-    , i    = 1;
-
-  str = str.replace(/%([sd])/g, function( _, type ) {
-    var arg = args[ i++ ];
-    switch(type) {
-      case 'd':
-        return arg | 0;
-      case 's':
-        return arg;
-    }
-  });
-
-  this.client.rpush(this.client.getKey('job:' + this.id + ':log'), str);
+Job.prototype.log = function() {
+  var formatted = util.format.apply(util, arguments);
+  this.client.rpush(this.client.getKey('job:' + this.id + ':log'), formatted);
   this.set('updated_at', Date.now());
   return this;
 };


### PR DESCRIPTION
This updates the `Job` API to use node's [`util#format()`](https://nodejs.org/api/util.html#util_util_format_format) function, allowing it to support all of the same modifiers that console.log supports, like `%j`.