### PR TITLE
Connection string not supporting DB number

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -32,6 +32,7 @@ exports.configureFactory = function( options, queue ) {
     options.redis = {
       port: conn_info.port || 6379,
       host: conn_info.hostname,
+      db: (conn_info.pathname ? conn_info.pathname.substr(1) : null) || 0,
       // see https://github.com/mranney/node_redis#rediscreateclient
       options: conn_info.query
     };
@@ -82,12 +83,13 @@ exports.createClientFactory = function( options ) {
   var socket = options.redis.socket;
   var port   = !socket ? (options.redis.port || 6379) : null;
   var host   = !socket ? (options.redis.host || '127.0.0.1') : null;
+  var db   = !socket ? (options.redis.db || 0) : null;
   var client = redis.createClient(socket || port, host, options.redis.options);
   if( options.redis.auth ) {
     client.auth(options.redis.auth);
   }
-  if( options.redis.db ) {
-    client.select(options.redis.db);
+  if( db >= 0 ){
+    client.select(db);
   }
   return client;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,153 @@
 var kue = require( '../' );
 
+describe('CONNECTION', function(){
+	var jobs = null;
+
+	afterEach( function ( done ) {
+		jobs.shutdown( 50, function () {
+			done()
+		} );
+	} );
+
+  it( 'should configure properly with string', function ( done ) {
+	  jobs = new kue( {
+		  redis: 'redis://localhost:6379/15?foo=bar'
+	  } );
+
+	  jobs.client.connectionOption.port.should.be.eql( 6379 );
+	  jobs.client.connectionOption.host.should.be.eql( 'localhost' );
+	  jobs.client.options.foo.should.be.eql( 'bar' );
+
+	  var jobData = {
+		  title: 'welcome email for tj',
+		  to: '"TJ" <tj@learnboost.com>',
+		  template: 'welcome-email'
+	  };
+	  jobs.create( 'email-should-be-processed-3', jobData ).priority( 'high' ).save();
+	  jobs.process( 'email-should-be-processed-3', function ( job, jdone ) {
+		  job.data.should.be.eql( jobData );
+		  job.log( '<p>This is <span style="color: green;">a</span> formatted log<p/>' );
+		  // Needs to be here to support the async client.select statement where the return happens sync but the call is async
+		  jobs.client.selected_db.should.be.eql(15);
+		  jdone();
+		  done();
+	  } );
+  });
+
+	it( 'should configure properly with dictionary', function ( done ) {
+		jobs = new kue( {
+			redis: {
+				host: 'localhost',
+				port: 6379,
+				db: 15,
+				options: {
+					foo: 'bar'
+				}
+			}
+		} );
+
+		jobs.client.connectionOption.port.should.be.eql( 6379 );
+		jobs.client.connectionOption.host.should.be.eql( 'localhost' );
+		jobs.client.options.foo.should.be.eql( 'bar' );
+
+		var jobData = {
+			title: 'welcome email for tj',
+			to: '"TJ" <tj@learnboost.com>',
+			template: 'welcome-email'
+		};
+		jobs.create( 'email-should-be-processed-4', jobData ).priority( 'high' ).save();
+		jobs.process( 'email-should-be-processed-4', function ( job, jdone ) {
+			job.data.should.be.eql( jobData );
+			job.log( '<p>This is <span style="color: green;">a</span> formatted log<p/>' );
+			// Needs to be here to support the async client.select statement where the return happens sync but the call is async
+			jobs.client.selected_db.should.be.eql(15);
+			jdone();
+			done();
+		} );
+	});
+
+	it( 'should default to 0 db with string', function ( done ) {
+		var jobs = new kue( {
+			redis: 'redis://localhost:6379/?foo=bar'
+		} );
+
+		jobs.client.connectionOption.port.should.be.eql( 6379 );
+		jobs.client.connectionOption.host.should.be.eql( 'localhost' );
+		jobs.client.options.foo.should.be.eql( 'bar' );
+
+		var jobData = {
+			title: 'welcome email for tj',
+			to: '"TJ" <tj@learnboost.com>',
+			template: 'welcome-email'
+		};
+		jobs.create( 'email-should-be-processed-5', jobData ).priority( 'high' ).save();
+		jobs.process( 'email-should-be-processed-5', function ( job, jdone ) {
+			job.data.should.be.eql( jobData );
+			job.log( '<p>This is <span style="color: green;">a</span> formatted log<p/>' );
+			jobs.client.selected_db.should.be.eql(0);
+			jdone();
+			done();
+		} );
+
+	});
+
+	it( 'should default to 0 db with string and no /', function ( done ) {
+		var jobs = new kue( {
+			redis: 'redis://localhost:6379?foo=bar'
+		} );
+
+		jobs.client.connectionOption.port.should.be.eql( 6379 );
+		jobs.client.connectionOption.host.should.be.eql( 'localhost' );
+		jobs.client.options.foo.should.be.eql( 'bar' );
+
+		var jobData = {
+			title: 'welcome email for tj',
+			to: '"TJ" <tj@learnboost.com>',
+			template: 'welcome-email'
+		};
+		jobs.create( 'email-should-be-processed-6', jobData ).priority( 'high' ).save();
+		jobs.process( 'email-should-be-processed-6', function ( job, jdone ) {
+			job.data.should.be.eql( jobData );
+			job.log( '<p>This is <span style="color: green;">a</span> formatted log<p/>' );
+			jobs.client.selected_db.should.be.eql(0);
+			jdone();
+			done();
+		} );
+
+	});
+
+	it( 'should configure properly with dictionary', function ( done ) {
+		jobs = new kue( {
+			redis: {
+				host: 'localhost',
+				port: 6379,
+				options: {
+					foo: 'bar'
+				}
+			}
+		} );
+
+		jobs.client.connectionOption.port.should.be.eql( 6379 );
+		jobs.client.connectionOption.host.should.be.eql( 'localhost' );
+		jobs.client.options.foo.should.be.eql( 'bar' );
+
+		var jobData = {
+			title: 'welcome email for tj',
+			to: '"TJ" <tj@learnboost.com>',
+			template: 'welcome-email'
+		};
+		jobs.create( 'email-should-be-processed-7', jobData ).priority( 'high' ).save();
+		jobs.process( 'email-should-be-processed-7', function ( job, jdone ) {
+			job.data.should.be.eql( jobData );
+			job.log( '<p>This is <span style="color: green;">a</span> formatted log<p/>' );
+			// Needs to be here to support the async client.select statement where the return happens sync but the call is async
+			jobs.client.selected_db.should.be.eql(0);
+			jdone();
+			done();
+		} );
+	});
+});
+
 describe( 'JOBS', function () {
 
   var jobs = null;


### PR DESCRIPTION
Added db number to connection string to support the same as object. Added tests for various different cases when using string or object.

*Feedback Request* = the current .select on the db is async when running the command on RedisClient causing problems for the expect if it was not further in the code. Could the changes be made to support callbacks?

