### PR TITLE
Properly set job IDs in test mode

### DIFF
--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -6,7 +6,7 @@ var originalJobSave   = Job.prototype.save,
     jobs;
 
 function testJobSave( fn ) {
-  this.id = _.uniqueId;
+  this.id = _.uniqueId();
   jobs.push(this);
   if( _.isFunction(fn) ) fn();
 };


### PR DESCRIPTION
I might be missing something here, but this is setting my IDs to a function when running in test mode. Seems like we should be explicitly calling `_.uniqueId` in order for the ID to be resolved. Or was this intentional?