### PR TITLE
Update link to Project GitHub page

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
       <h1>Kue</h1>
       <ul>
         <li>
-          <p><a href="http://github.com/learnboost/kue">Kue</a> is a feature rich priority job queue for node.js backed by redis. A key feature of Kue is its clean user-interface for viewing and managing queued, active, failed, and completed jobs.</p>
+          <p><a href="https://github.com/Automattic/kue">Kue</a> is a feature rich priority job queue for node.js backed by redis. A key feature of Kue is its clean user-interface for viewing and managing queued, active, failed, and completed jobs.</p>
           <img src='images/ui.png' title="user interface" />
         </li>
 
@@ -36,6 +36,6 @@
         </li>
       </ul>
     </div>
-<a href="http://github.com/learnboost/kue"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
+<a href="https://github.com/Automattic/kue"><img style="position: absolute; top: 0; right: 0; border: 0;" src="https://s3.amazonaws.com/github/ribbons/forkme_right_darkblue_121621.png" alt="Fork me on GitHub"></a>
   </body>
 </html>


### PR DESCRIPTION
Update the links in the documentation page from
http://github.com/learnboost/kue to https://github.com/Automattic/kue