### PR TITLE
Update jade to latest 1.11.0 due to security bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "body-parser": "^1.12.2",
     "express": "^4.12.2",
-    "jade": "1.1.5",
+    "jade": "^1.11.0",
     "lodash": "^2.4.1",
     "lodash-deep": "^1.1.0",
     "nib": "0.5.0",


### PR DESCRIPTION
There is security bug in uglify-js  `<= 2.4.23 ` (https://nodesecurity.io/advisories/uglifyjs_incorrectly_handles_non-boolean_comparisons)
Here is the full dependency tree:
`kue (0.9.6) → jade (1.1.5) → transformers (2.1.0) → uglify-js (2.2.5)`

So updating jade to latest version to latest removed this security bug in kue as well.