### PR TITLE
Fix logic in attempts remaining check

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -309,7 +309,7 @@ Job.prototype.toJSON = function() {
     , ttl: this._ttl
     , attempts: {
       made: Number(this._attempts) || 0
-      , remaining: this._attempts ? this._max_attempts - this._attempts : Number(this._max_attempts) || 1
+      , remaining: this._attempts > 0 ? this._max_attempts - this._attempts : Number(this._max_attempts) || 1
       , max: Number(this._max_attempts) || 1
     }
   };


### PR DESCRIPTION
A race condition in our app was causing some jobs to be failed twice, bringing `Job._attempts` below 0, which resulted in the truthiness check `-1 ?...` below passing and the job being retried indefinitely. I'm still trying to track down the race condition, but this fix appears to prevent that behavior.