### PR TITLE
fix job.emit stringify on circular objects

### DIFF
--- a/lib/queue/events.js
+++ b/lib/queue/events.js
@@ -120,8 +120,19 @@ exports.onMessage = function( channel, msg ) {
 
 exports.emit = function( id, event ) {
   var client = redis.client()
-    , msg    = JSON.stringify({
-        id: id, event: event, args: [].slice.call(arguments, 1)
-      });
+    , msg;
+
+  try {
+    msg = JSON.stringify({
+      id: id, event: event, args: [].slice.call(arguments, 1)
+    });
+  } catch (e) {
+    console.error(e);
+    msg = JSON.stringify({
+      // skip troublesome arguments
+      id: id, event: event, args: [ event ]
+    });
+  }
+
   client.publish(client.getKey(exports.key), msg);
 };

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,7 @@
-var kue = require( '../' );
+var kue  = require( '../' ),
+    chai = require( 'chai' );
+
+expect = chai.expect;
 
 describe('CONNECTION', function(){
 	var jobs = null;
@@ -223,4 +226,21 @@ describe( 'JOBS', function () {
       done();
     } );
   } );
-} );
+
+  it( 'should skip data on complete if passed circular objects', function ( done ) {
+    var job = jobs.create( 'circular-data-should-be-processed' ).priority( 'high' ).save();
+
+    job.on( 'complete', function ( data ) {
+      expect( data ).to.not.exist;
+
+      done();
+    });
+
+    jobs.process( 'circular-data-should-be-processed', function ( job, jdone ) {
+      var circularData = {};
+      circularData.circular = circularData;
+
+      jdone( null, circularData );
+    });
+  });
+});

--- a/test/test_mode.js
+++ b/test/test_mode.js
@@ -1,8 +1,22 @@
 var kue = require('../'),
-    _ = require('lodash'),
-    queue = kue.createQueue();
+    _ = require('lodash');
 
 describe('Test Mode', function() {
+    // Moved queue creation in before as it's a singleton.
+    // Indeed, when shut down, this.client is set to null,
+    // hence we want a fresh instance for disabled mode.
+    var queue;
+
+    before(function () {
+        queue = kue.createQueue();
+    });
+
+    after(function (done) {
+        queue.shutdown(50, function() {
+            done();
+        });
+    });
+
     context('when enabled', function() {
         before(function() {
             queue.testMode.enter();


### PR DESCRIPTION
Hi there,

I've run into this issue when cascading using `async` module and returning a job to the callback of a job processing.
As jobs are circular, that had the effect of completely crashing my app.

Here's a proposal to avoid crashing, using `try/catch`, performances might get slightly affected although it is already used here (https://github.com/Automattic/kue/blob/master/lib/queue/worker.js#L178-L183).
Provided tests should fail if this patch to `events.js` is not applied.

Tell me what you think.

Cheers!