### PR TITLE
Fix uncaught exception in job.js

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -570,7 +570,7 @@ Job.prototype.failedAttempt = function( theErr, fn ) {
             return fn && fn( err );
           }
           fn && fn( err, true, attempts );
-        });
+        }.bind(this));
       } else {
         fn && fn( null, false, attempts );
       }


### PR DESCRIPTION
Fix missing bind that is causing uncaught exception and process termination.