### PR TITLE
Fixed invalid CSS, bumped stylus (take 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,5 @@
 .DS_Store
 node_modules
 *.sock
-lib/http/public/stylesheets/main.css
 *.rdb
 test/incomplete

--- a/lib/http/public/stylesheets/context-menu.styl
+++ b/lib/http/public/stylesheets/context-menu.styl
@@ -21,5 +21,4 @@ highlight-color = #00B3E9
         color: white
         border: 1px solid white
       &:active
-        highlight-color += 10%
-        background: linear-gradient(bottom, highlight-color, highlight-color + 50%)
+        background: linear-gradient(bottom, highlight-color + 10%, highlight-color + 10% + 50%)

--- a/lib/http/public/stylesheets/main.css
+++ b/lib/http/public/stylesheets/main.css
@@ -1,0 +1,435 @@
+body {
+  padding: 50px 120px;
+}
+#menu {
+  margin: 0;
+  padding: 0;
+  position: fixed;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 80px;
+  background: #3b3b3b;
+  border-right: 1px solid #232323;
+  -webkit-box-shadow: 0 0 0 1px rgba(255,255,255,0.5);
+  box-shadow: 0 0 0 1px rgba(255,255,255,0.5);
+}
+#menu li {
+  margin: 0;
+  list-style: none;
+}
+#menu li {
+  position: relative;
+  text-align: center;
+}
+#menu li .count {
+  position: absolute;
+  top: 15px;
+  left: 0;
+  text-shadow: 1px 1px 1px #333;
+  width: 100%;
+  color: #808080;
+}
+#menu li a {
+  display: block;
+  padding: 40px 0 10px 0;
+  color: #777;
+  border-top: 1px solid #545454;
+  border-bottom: 1px solid #333;
+  font-size: 12px;
+  background: #3a3a3a;
+}
+#menu li a:hover {
+  background: #444;
+}
+#menu li a:active,
+#menu li a.active {
+  background: #343434;
+  -webkit-box-shadow: inset 0 0 3px 2px #292929, inset 0 -5px 10px 2px #313131;
+  box-shadow: inset 0 0 3px 2px #292929, inset 0 -5px 10px 2px #313131;
+  border-bottom: 1px solid #232323;
+}
+.context-menu {
+  display: none;
+  margin: 0;
+  padding: 0;
+  border: 1px solid #eee;
+  border-bottom-color: rgba(0,0,0,0.25);
+  border-left-color: rgba(0,0,0,0.2);
+  border-right-color: rgba(0,0,0,0.2);
+  -webkit-box-shadow: 0 2px 2px 0 rgba(0,0,0,0.1);
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,0.1);
+  -webkit-border-radius: 4px;
+  border-radius: 4px;
+}
+.context-menu li {
+  margin: 0;
+  list-style: none;
+}
+.context-menu li:last-child a {
+  border-bottom: none;
+}
+.context-menu li a {
+  display: block;
+  background: #fff;
+  padding: 5px 10px;
+  border: 1px solid transparent;
+  border-bottom: 1px solid #eee;
+  font-size: 12px;
+}
+.context-menu li a:hover {
+  background: -webkit-gradient(linear, left bottom, left top, color-stop(0, #00b3e9), color-stop(1, #74dfff));
+  background: -webkit-linear-gradient(bottom, #00b3e9 0%, #74dfff 100%);
+  background: -moz-linear-gradient(bottom, #00b3e9 0%, #74dfff 100%);
+  background: -o-linear-gradient(bottom, #00b3e9 0%, #74dfff 100%);
+  background: -ms-linear-gradient(bottom, #00b3e9 0%, #74dfff 100%);
+  background: linear-gradient(bottom, #00b3e9 0%, #74dfff 100%);
+  color: #fff;
+  border: 1px solid #fff;
+}
+.context-menu li a:active {
+  background: -webkit-gradient(linear, left bottom, left top, color-stop(0, #06c5ff), color-stop(1, #83e2ff));
+  background: -webkit-linear-gradient(bottom, #06c5ff 0%, #83e2ff 100%);
+  background: -moz-linear-gradient(bottom, #06c5ff 0%, #83e2ff 100%);
+  background: -o-linear-gradient(bottom, #06c5ff 0%, #83e2ff 100%);
+  background: -ms-linear-gradient(bottom, #06c5ff 0%, #83e2ff 100%);
+  background: linear-gradient(bottom, #06c5ff 0%, #83e2ff 100%);
+}
+#job-template {
+  display: none;
+}
+.block {
+  border: 1px solid #eee;
+  border-bottom-color: rgba(0,0,0,0.25);
+  border-left-color: rgba(0,0,0,0.2);
+  border-right-color: rgba(0,0,0,0.2);
+  -webkit-box-shadow: 0 2px 2px 0 rgba(0,0,0,0.1);
+  box-shadow: 0 2px 2px 0 rgba(0,0,0,0.1);
+  -webkit-border-radius: 4px;
+  border-radius: 4px;
+  width: 90%;
+  margin: 10px 25px;
+  padding: 20px 25px;
+}
+.block h2 {
+  margin: 0;
+  position: absolute;
+  top: 5px;
+  left: -15px;
+  padding: 5px;
+  font-size: 10px;
+  -moz-border-radius-topleft: 5px;
+  -webkit-border-top-left-radius: 5px;
+  -o-border-top-left-radius: 5px;
+  -ms-border-top-left-radius: 5px;
+  border-top-left-radius: 5px;
+  -moz-border-radius-bottomleft: 5px;
+  -webkit-border-bottom-left-radius: 5px;
+  -o-border-bottom-left-radius: 5px;
+  -ms-border-bottom-left-radius: 5px;
+  border-bottom-left-radius: 5px;
+  -moz-border-radius-topright: 2px;
+  -webkit-border-top-right-radius: 2px;
+  -o-border-top-right-radius: 2px;
+  -ms-border-top-right-radius: 2px;
+  border-top-right-radius: 2px;
+  -moz-border-radius-bottomright: 2px;
+  -webkit-border-bottom-right-radius: 2px;
+  -o-border-bottom-right-radius: 2px;
+  -ms-border-bottom-right-radius: 2px;
+  border-bottom-right-radius: 2px;
+  background: -webkit-gradient(linear, left top, right top, color-stop(0, #6b6b6b), color-stop(0.5, #7e7e7e));
+  background: -webkit-linear-gradient(left, #6b6b6b 0%, #7e7e7e 50%);
+  background: -moz-linear-gradient(left, #6b6b6b 0%, #7e7e7e 50%);
+  background: -o-linear-gradient(left, #6b6b6b 0%, #7e7e7e 50%);
+  background: -ms-linear-gradient(left, #6b6b6b 0%, #7e7e7e 50%);
+  background: linear-gradient(left, #6b6b6b 0%, #7e7e7e 50%);
+  -webkit-box-shadow: -1px 0 1px 1px rgba(0,0,0,0.1);
+  box-shadow: -1px 0 1px 1px rgba(0,0,0,0.1);
+  color: #fff;
+  text-shadow: 1px 1px 1px #444;
+}
+.block .type {
+  color: #929292;
+}
+.job td.title em {
+  color: #929292;
+}
+.job .block {
+  position: relative;
+  background: #fff;
+  cursor: pointer;
+}
+.job .block table td:first-child {
+  display: none;
+}
+.job .block .progress {
+  position: absolute;
+  top: 15px;
+  right: 20px;
+}
+.job .block .attempts {
+  display: none;
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 5px 8px;
+  -webkit-border-radius: 2px;
+  border-radius: 2px;
+  font-size: 10px;
+}
+.job .block .remove {
+  position: absolute;
+  top: 30px;
+  right: -6px;
+/*background: white*/
+  background: #f05151;
+  color: #fff;
+  display: block;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  text-align: center;
+  font-size: 12px;
+  font-weight: bold;
+  outline: none;
+  border: 1px solid #eee;
+  -webkit-border-radius: 20px;
+  border-radius: 20px;
+  -webkit-transition: opacity 200ms, top 300ms;
+  -moz-transition: opacity 200ms, top 300ms;
+  -o-transition: opacity 200ms, top 300ms;
+  -ms-transition: opacity 200ms, top 300ms;
+  transition: opacity 200ms, top 300ms;
+  opacity: 0;
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=0);
+  filter: alpha(opacity=0);
+}
+.job .block .remove:hover {
+  border: 1px solid #d6d6d6;
+}
+.job .block .remove:active {
+  border: 1px solid #bebebe;
+}
+.job .block .restart {
+  position: absolute;
+  top: 30px;
+  right: -6px;
+/*background: white*/
+  background: #00e600;
+  color: #fff;
+  display: block;
+  width: 20px;
+  height: 20px;
+  line-height: 20px;
+  text-align: center;
+  font-size: 12px;
+  font-weight: bold;
+  outline: none;
+  border: 1px solid #eee;
+  -webkit-border-radius: 20px;
+  border-radius: 20px;
+  -webkit-transition: opacity 200ms, top 300ms;
+  -moz-transition: opacity 200ms, top 300ms;
+  -o-transition: opacity 200ms, top 300ms;
+  -ms-transition: opacity 200ms, top 300ms;
+  transition: opacity 200ms, top 300ms;
+  opacity: 0;
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=0);
+  filter: alpha(opacity=0);
+}
+.job .block .restart:hover {
+  border: 1px solid #d6d6d6;
+}
+.job .block .restart:active {
+  border: 1px solid #bebebe;
+}
+.job .block:hover .remove {
+  opacity: 1;
+  -ms-filter: none;
+  filter: none;
+  top: -6px;
+}
+.job .block:hover .restart {
+  opacity: 1;
+  -ms-filter: none;
+  filter: none;
+  top: 16px;
+}
+.job .details {
+  background: #3b3b3b;
+  width: 89%;
+  margin-top: -10px;
+  margin-left: 35px;
+  -moz-border-radius-bottomleft: 5px;
+  -webkit-border-bottom-left-radius: 5px;
+  -o-border-bottom-left-radius: 5px;
+  -ms-border-bottom-left-radius: 5px;
+  border-bottom-left-radius: 5px;
+  -moz-border-radius-bottomright: 5px;
+  -webkit-border-bottom-right-radius: 5px;
+  -o-border-bottom-right-radius: 5px;
+  -ms-border-bottom-right-radius: 5px;
+  border-bottom-right-radius: 5px;
+  -webkit-box-shadow: inset 0 1px 10px 0 rgba(0,0,0,0.8);
+  box-shadow: inset 0 1px 10px 0 rgba(0,0,0,0.8);
+  -webkit-transition: padding 200ms, height 200ms;
+  -moz-transition: padding 200ms, height 200ms;
+  -o-transition: padding 200ms, height 200ms;
+  -ms-transition: padding 200ms, height 200ms;
+  transition: padding 200ms, height 200ms;
+  height: 0;
+  overflow: hidden;
+}
+.job .details table {
+  width: 100%;
+}
+.job .details table td:first-child {
+  width: 60px;
+  color: #949494;
+}
+.job .details.show {
+  padding: 15px 20px;
+  height: auto;
+}
+.job ul.log {
+  margin: 0;
+  padding: 0;
+  margin: 5px;
+  padding: 10px;
+  max-height: 100px;
+  overflow-y: auto;
+  -webkit-border-radius: 5px;
+  border-radius: 5px;
+  width: 95%;
+}
+.job ul.log li {
+  margin: 0;
+  list-style: none;
+}
+.job ul.log li {
+  padding: 5px 0;
+  border-bottom: 1px dotted #424242;
+  color: #666;
+}
+.job ul.log li:last-child {
+  border-bottom: none;
+}
+.job .details ::-webkit-scrollbar {
+  width: 2px;
+}
+.job .details ::-webkit-scrollbar-thumb:vertical {
+  background: #858585;
+}
+.job .details ::-webkit-scrollbar-track {
+  border: 1px solid rgba(255,255,255,0.1);
+}
+.job .details > div {
+  padding: 10px 0;
+  border-bottom: 1px solid #424242;
+}
+.job .details > div:last-child {
+  border-bottom: none;
+}
+#actions {
+  position: fixed;
+  top: -2px;
+  right: -2px;
+  z-index: 20;
+}
+#sort,
+#filter,
+#search {
+  float: left;
+  margin: 0;
+  padding: 5px 10px;
+  border: 1px solid #eee;
+  -webkit-border-radius: 0 0 0 5px;
+  border-radius: 0 0 0 5px;
+  -webkit-appearance: none;
+  color: #3b3b3b;
+  outline: none;
+}
+#sort:hover,
+#filter:hover,
+#search:hover {
+  border-color: #d6d6d6;
+}
+#sort,
+#filter {
+  cursor: pointer;
+}
+#sort,
+#filter {
+  -webkit-border-radius: 0;
+  border-radius: 0;
+  border-left: none;
+}
+#error {
+  position: fixed;
+  top: -50px;
+  right: 15px;
+  padding: 20px;
+  -webkit-transition: top 500ms, opacity 500ms;
+  -moz-transition: top 500ms, opacity 500ms;
+  -o-transition: top 500ms, opacity 500ms;
+  -ms-transition: top 500ms, opacity 500ms;
+  transition: top 500ms, opacity 500ms;
+  opacity: 0;
+  -ms-filter: progid:DXImageTransform.Microsoft.Alpha(Opacity=0);
+  filter: alpha(opacity=0);
+  background: rgba(59,59,59,0.2);
+  border: 1px solid rgba(59,59,59,0.3);
+  -webkit-border-radius: 5px;
+  border-radius: 5px;
+  color: #3b3b3b;
+}
+#error.show {
+  top: 15px;
+  opacity: 1;
+  -ms-filter: none;
+  filter: none;
+}
+body {
+  font: 13px "helvetica neue", helvetica, arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  background: #fff;
+  color: #666;
+}
+h1,
+h2,
+h3 {
+  margin: 0 0 25px 0;
+  padding: 0;
+  font-weight: normal;
+  text-transform: capitalize;
+  color: #666;
+}
+h2 {
+  font-size: 16px;
+  margin-top: 20px;
+}
+pre {
+  margin-top: 20px;
+}
+a {
+  text-decoration: none;
+  cursor: pointer;
+}
+table {
+  border-collapse: separate;
+  border-spacing: 0;
+  vertical-align: middle;
+}
+table tr td {
+  padding: 2px 5px;
+}
+#loading {
+  width: 100%;
+  text-align: center;
+  margin-top: 40px;
+  margin-left: 20px;
+}
+#loading canvas {
+  margin: 0 auto;
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "node-redis-warlock": "^0.1.2",
     "redis": "~0.12.0",
     "reds": "~0.2.5",
-    "stylus": "0.42.2",
+    "stylus": "~0.52.4",
     "yargs": "^3.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Rebased and updated version of the #712

"highlight-color += 10%" in context-menu.styl produces
an invalid color entry in CSS
Added main.css to avoid requiring write access to the node_modules dir in production