### PR TITLE
start using autoroute to clean up routes

### DIFF
--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -13,8 +13,7 @@ var express = require('express');
 // setup
 
 var app        = express()
-  , bodyParser = require('body-parser')
-  , provides   = require('./middleware/provides')
+  , autoroute  = require('express-autoroute')
   , stylus     = require('stylus')
   , routes     = require('./routes')
   , jade       = require('jade')
@@ -48,22 +47,10 @@ app.locals     = { inspect: util.inspect };
 app.use(stylus.middleware({ src: __dirname + '/public', compile: compile }));
 app.use(express.static(__dirname + '/public'));
 
-// JSON api
-
-app.get('/stats', provides('json'), json.stats);
-app.get('/job/search', provides('json'), json.search);
-app.get('/jobs/:from..:to/:order?', provides('json'), json.jobRange);
-app.get('/jobs/:type/:state/:from..:to/:order?', provides('json'), json.jobTypeRange);
-app.get('/jobs/:type/:state/stats', provides('json'), json.jobTypeStateStats);
-app.get('/jobs/:state/:from..:to/:order?', provides('json'), json.jobStateRange);
-app.get('/job/types', provides('json'), json.types);
-app.get('/job/:id', provides('json'), json.job);
-app.get('/job/:id/log', provides('json'), json.log);
-app.put('/job/:id/state/:state', provides('json'), json.updateState);
-app.put('/job/:id/priority/:priority', provides('json'), json.updatePriority);
-app.delete('/job/:id', provides('json'), json.remove);
-app.post('/job', provides('json'), bodyParser.json(), json.createJob);
-app.get('/inactive/:id', provides('json'), json.inactive);
+//load autoroute files
+autoroute(app, {
+	routesDir: __dirname + '/routes'
+});
 
 // routes
 

--- a/lib/http/routes/inactive.js
+++ b/lib/http/routes/inactive.js
@@ -1,0 +1,8 @@
+var json = require('./json');
+var provides = require('../middleware/provides');
+
+module.exports.autoroute = {
+    get: {
+        '/inactive/:id': [provides('json'), json.inactive]
+    }
+};

--- a/lib/http/routes/job.js
+++ b/lib/http/routes/job.js
@@ -1,0 +1,22 @@
+var bodyParser = require('body-parser');
+var json = require('./json');
+var provides = require('../middleware/provides');
+
+module.exports.autoroute = {
+    get: {
+        '/job/search': [provides('json'), json.search],
+        '/job/types': [provides('json'), json.types],
+        '/job/:id': [provides('json'), json.job],
+        '/job/:id/log': [provides('json'), json.log]
+    },
+    put: {
+        '/job/:id/state/:state': [provides('json'), json.updateState],
+        '/job/:id/priority/:priority': [provides('json'), json.updatePriority]
+    },
+    post: {
+        '/job': [provides('json'), bodyParser.json(), json.createJob]
+    },
+    delete: {
+        '/job/:id': [provides('json'), json.remove]
+    }
+};

--- a/lib/http/routes/jobs.js
+++ b/lib/http/routes/jobs.js
@@ -1,0 +1,11 @@
+var json = require('./json');
+var provides = require('../middleware/provides');
+
+module.exports.autoroute = {
+    get: {
+        '/jobs/:from..:to/:order?': [provides('json'), json.jobRange],
+        '/jobs/:type/:state/:from..:to/:order?': [provides('json'), json.jobTypeRange],
+        '/jobs/:type/:state/stats': [provides('json'), json.jobTypeStateStats],
+        '/jobs/:state/:from..:to/:order?': [provides('json'), json.jobStateRange]
+    }
+};

--- a/lib/http/routes/stats.js
+++ b/lib/http/routes/stats.js
@@ -1,0 +1,8 @@
+var json = require('./json');
+var provides = require('../middleware/provides');
+
+module.exports.autoroute = {
+    get: {
+        '/stats': [provides('json'), json.stats]
+    }
+};

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "body-parser": "^1.12.2",
     "express": "^4.12.2",
+    "express-autoroute": "^1.2.3",
     "jade": "^1.11.0",
     "lodash": "^3.10.1",
     "lodash-deep": "^1.1.0",


### PR DESCRIPTION
I'm just about to create a new PR to add a new route (or extend an existing route) and I wanted to make it easier for other users to extend routes in the future by cleaning up the file that defines the API routes using https://github.com/stonecircle/express-autoroute

The intention would be to split the https://github.com/Automattic/kue/blob/master/lib/http/routes/json.js file into the corresponding route files but I didn't want to go further into this implementation without running it by you. 

Let me know if you want to discuss it any further or if you have any questions.