### PR TITLE
Add yargs dependency for kue-dashboard

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "node-redis-warlock": "^0.1.2",
     "redis": "^2.3.0",
     "reds": "~0.2.5",
-    "stylus": "~0.52.4"
+    "stylus": "~0.52.4",
+    "yargs": "^3.31.0"
   },
   "devDependencies": {
     "async": "^1.4.2",


### PR DESCRIPTION
The `yargs` dependency for kue-dashboard seems to have been left out since 0.10.4. 

This addresses https://github.com/Automattic/kue/issues/762