### PR TITLE
Adds support for iso date string delay

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -15,6 +15,7 @@ var EventEmitter = require('events').EventEmitter
   , reds         = require('reds')
   , _            = require('lodash')
   , util         = require('util')
+  , moment       = require('moment')
   , noop         = function() {
 };
 
@@ -442,8 +443,11 @@ Job.prototype.progress = function( complete, total, data ) {
 
 Job.prototype.delay = function( ms ) {
   if( 0 == arguments.length ) return this._delay;
+  var isoDate = moment(ms, moment.ISO_8601, true);
   if( _.isDate(ms) ) {
     ms = parseInt(ms.getTime() - Date.now())
+  } else if( isoDate.isValid() ) {
+    ms = isoDate.diff(moment())
   }
   if( ms > 0 ) {
     this._delay = ms;

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "jade": "^1.11.0",
     "lodash": "^3.10.1",
     "lodash-deep": "^1.1.0",
+    "moment": "^2.11.1",
     "nib": "~1.1.0",
     "node-redis-warlock": "^0.1.2",
     "redis": "^2.4.2",

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -178,7 +178,14 @@ describe 'Kue Tests', ->
         jdone()
         done()
 
-
+    it 'should support iso date strings', (done) ->
+      now = Date.now()
+      jobs.create( 'simple-delay-job', { title: 'simple delay job' } ).delay((new Date(now + 300)).toISOString()).save()
+      jobs.process 'simple-delay-job', (job, jdone) ->
+        processed = Date.now()
+        (processed - now).should.be.approximately( 300, 100 )
+        jdone()
+        done()
 
     it 'should have promote_at timestamp', (done) ->
       now = Date.now()


### PR DESCRIPTION
My company is working on adding a kue server for running jobs at particular dates in the future. To do that we need to be able to provide a date for the job via the JSON API. However, we quickly realized that the date is not recognized by kue. The reason for that is because the code uses lodash’s `isDate` method which only checks whether the value is a classified `Date` object. Dates are passed as strings via JSON so the check fails and the job is executed immediately.

This PR adds support for ISO formatted date strings by using [moment.js](http://momentjs.com/)