### PR TITLE
Modern Node.js versions support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
   - "0.10"
+  - "0.12"
   - "4.2"
   - "5.5"
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
   - "0.10"
+  - "4.2"
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,6 @@ language: node_js
 node_js:
   - "0.10"
   - "4.2"
+  - "5.5"
 services:
   - redis-server

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -371,7 +371,7 @@ Queue.prototype.shutdown = function( timeout, type, fn ) {
     };
 
   if( this.shuttingDown && type === '' ) { // a global shutdown already has been called
-    return fn('Shutdown already in progress');
+    return fn(new Error('Shutdown already in progress'));
   }
 
   if( type === '' ) { // this is a global shutdown call

--- a/test/shutdown.coffee
+++ b/test/shutdown.coffee
@@ -133,7 +133,9 @@ describe 'Kue', ->
 
         setTimeout ()->
           jobs.shutdown 100, (err)->
-            err.should.be.equal "Shutdown already in progress"
+            should.exist err, 'expected `err` to exist'
+            err.should.be.an.instanceOf(Error)
+              .with.property('message', 'Shutdown already in progress')
             testDone()
         , 60
 


### PR DESCRIPTION
Node.js currently supports **v4.2.6 LTS** and *v5.5.0 Latest Stable*, let's make tests run against them in Travis.