### PR TITLE
Add basic "contributing rules" to README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -896,6 +896,21 @@ it('does something cool', function() {
   - [Introduction](http://www.screenr.com/oyNs) to Kue
   - API [walkthrough](https://vimeo.com/26963384) to Kue
 
+## Contributing
+
+**We love contributions!**
+
+When contributing, follow the simple rules:
+
+* Don't violate [DRY](http://programmer.97things.oreilly.com/wiki/index.php/Don%27t_Repeat_Yourself) principles.
+* [Boy Scout Rule](http://programmer.97things.oreilly.com/wiki/index.php/The_Boy_Scout_Rule) needs to have been applied.
+* Your code should look like all the other code – this project should look like it was written by one man, always.
+* If you want to propose something – just create an issue and describe your question with as much description as you can.
+* If you think you have some general improvement, consider creating a pull request with it.
+* If you add new code, it should be covered by tests. No tests – no code.
+* If you add a new feature, don't forget to update the documentation for it.
+* If you find a bug (or at least you think it is a bug), create an issue with the library version and test case that we can run and see what are you talking about, or at least full steps by which we can reproduce it.
+
 ## License
 
 (The MIT License)


### PR DESCRIPTION
At the time I don't know too much about _exact_ development process for this projects, and seems only owners can add more detailed _CONTRIBUTING_ section. I'm just suggesting to add this simple, but golden rules (I beleive) to the README file.