### PR TITLE
Add parameter for testMode.enter to continue processing jobs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -891,6 +891,15 @@ it('does something cool', function() {
 });
 ```
 
+**IMPORTANT:** By default jobs aren't processed when created during test mode. You can enable job processing by passing true to testMode.enter
+
+```js
+before(function() {
+  queue.testMode.enter(true);
+});
+```
+
+
 ## Screencasts
 
   - [Introduction](http://www.screenr.com/oyNs) to Kue

--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -3,16 +3,26 @@ var Job = require('./job'),
 
 var originalJobSave   = Job.prototype.save,
     originalJobUpdate = Job.prototype.update,
+    processQueue,
     jobs;
 
 function testJobSave( fn ) {
-  this.id = _.uniqueId();
-  jobs.push(this);
-  if( _.isFunction(fn) ) fn();
+  if(processQueue) {
+    jobs.push(this);
+    originalJobSave.call(this, fn);
+  } else {
+    this.id = _.uniqueId();
+    jobs.push(this);
+    if( _.isFunction(fn) ) fn();    
+  }
 };
 
 function testJobUpdate( fn ) {
-  if( _.isFunction(fn) ) fn();
+  if(processQueue) {
+    originalJobUpdate.call(this, fn);
+  } else {
+    if( _.isFunction(fn) ) fn();
+  }
 };
 
 /**
@@ -21,13 +31,15 @@ function testJobUpdate( fn ) {
  */
 
 module.exports.jobs = jobs = [];
+module.exports.processQueue = processQueue = false;
 
 /**
  * Enable test mode.
  * @api public
  */
 
-module.exports.enter = function() {
+module.exports.enter = function(process) {
+  processQueue         = process || false;
   Job.prototype.save   = testJobSave;
   Job.prototype.update = testJobUpdate;
 };

--- a/test/test_mode.js
+++ b/test/test_mode.js
@@ -23,6 +23,31 @@ describe('Test Mode', function() {
             expect(job.data).to.eql({ foo: 'bar' });
         });
 
+        it('adds jobs to an array in memory and processes them when processQueue is true', function(done) {
+            queue.testMode.exit();
+            queue.testMode.enter(true);
+
+            queue.createJob('test-testMode-process', { foo: 'bar' }).save();
+
+            var jobs = queue.testMode.jobs;
+            expect(jobs.length).to.equal(1);
+
+            var job = _.last(jobs);
+            expect(job.type).to.equal('test-testMode-process');
+            expect(job.data).to.eql({ foo: 'bar' });
+
+            job.on('complete', function() {
+                queue.testMode.exit();
+                queue.testMode.enter();
+                done();
+            });
+
+            queue.process('test-testMode-process', function(job, jdone) {
+                job.data.should.be.eql({ foo: 'bar' });
+
+                jdone();
+            });
+        });
 
         describe('#clear', function() {
             it('resets the list of jobs', function() {


### PR DESCRIPTION
As discussed here: #820 

Adds a boolean parameter to testMode.enter which when set to true won't prevent jobs from processing.

Also adds documentation around this and clarifies that the default value prevents the queue from processing.

A test is included and the default behaviour of testMode.enter() with no arguments passed is the same as before so no functionality is broken.

Let me know if anything else is required :)