### PR TITLE
Bump node_redis version to 2.6.x

### DIFF
--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -268,7 +268,7 @@ Worker.prototype.getJob = function( fn ) {
   // BLPOP indicates we have a new inactive job to process
   client.blpop(client.getKey(self.type + ':jobs'), 0, function( err ) {
     if( err || !self.running ) {
-      if( self.client && self.client.connected ) {
+      if( self.client && self.client.connected && !self.client.closing ) {
         self.client.lpush(self.client.getKey(self.type + ':jobs'), 1);
       }
       return fn(err);		// SAE: Added to avoid crashing redis on zpop

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "lodash-deep": "^1.1.0",
     "nib": "~1.1.0",
     "node-redis-warlock": "~0.1.2",
-    "redis": "~2.4.2",
+    "redis": "~2.6.0-2",
     "reds": "~0.2.5",
     "stylus": "~0.52.4",
     "yargs": "^3.31.0"


### PR DESCRIPTION
Solves #876 
Also, node_redis version `2.6.0-2 ` broke some tests, Reproducing bug #823 
That's why I added a check testing if the client is currently closing.
