### PR TITLE
Add ioredis support to watchStuckJobs

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -271,6 +271,11 @@ Queue.prototype.watchStuckJobs = function( ms ) {
     , self   = this
     , ms     = ms || 1000;
   var prefix = this.client.prefix;
+
+  if( this.client.constructor.name == 'Redis'  || this.client.constructor.name == 'Cluster') {
+    // {prefix}:jobs format is needed in using ioredis cluster to keep they keys in same node
+    prefix = '{' + prefix + '}';
+  }
   var script =
         'local msg = redis.call( "keys", "' + prefix + ':jobs:*:inactive" )\n\
         local need_fix = 0\n\


### PR DESCRIPTION
The `watchStuckJobs` doesn't work for ioredis cause the prefix is different. This PR is a patch for it.