### PR TITLE
Add locking for FIFO support in multi server environment

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -313,6 +313,18 @@ queue.process('email', 20, function(job, done){
 });
 ```
 
+#### Ensuring job order across multiple servers
+
+If you are working in a multi server environment where `queue.process()` will be called on multiple servers for the same job type, but you need to avoid race conditions, you can pass in an options object. Setting `singleWorker = true` will use redis locking so only one server can be processing a job of a certain type at once. Once the job is `done()`, the lock is removed and any available server will pick up the next job.
+
+```js
+queue.process({
+  type: 'email',
+  singleWorker: true,
+  lockTtl: '5000' // default is 10000ms
+})
+```
+
 ### Pause Processing
 
 Workers can temporary pause and resume their activity. It is, after calling `pause` they will receive no jobs in their process callback until `resume` is called. `pause` function gracefully shutdowns this worker, and uses the same internal functionality as `shutdown` method in [Graceful Shutdown](#graceful-shutdown).

--- a/lib/kue.js
+++ b/lib/kue.js
@@ -317,19 +317,29 @@ Queue.prototype.setting = function( name, fn ) {
 /**
  * Process jobs with the given `type`, invoking `fn(job)`.
  *
- * @param {String} type
+ * @param {String|Object} type
  * @param {Number|Function} n
  * @param {Function} fn
  * @api public
  */
 
 Queue.prototype.process = function( type, n, fn ) {
-  var self = this;
+  var self    = this
+    , options, singleWorker, lockTtl;
 
-  if( 'function' == typeof n ) fn = n, n = 1;
+  if ('object' == typeof type) {
+    options = type;
+    type = options.type;
+    lockTtl = options.lockTtl;
+    singleWorker = true;
+    fn = n;
+    n = 1;
+  } else if ('function' == typeof n) {
+    fn = n, n = 1;
+  }
 
   while( n-- ) {
-    var worker = new Worker(this, type).start(fn);
+    var worker = new Worker(this, type, singleWorker, lockTtl).start(fn);
     worker.id  = [ self.id, type, self.workers.length + 1 ].join(':');
     worker.on('error', function( err ) {
       self.emit('error', err);

--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -13,6 +13,7 @@
 var EventEmitter = require('events').EventEmitter
   , redis        = require('../redis')
   , events       = require('./events')
+  , Warlock      = require('node-redis-warlock')
   , Job          = require('./job')
   , noop         = function() {
 };
@@ -38,12 +39,20 @@ var clients = {};
  * @api private
  */
 
-function Worker( queue, type ) {
+function Worker( queue, type, singleWorker, lockTtl ) {
+  var lockKey;
   this.queue   = queue;
   this.type    = type;
   this.client  = Worker.client || (Worker.client = redis.createClient());
   this.running = true;
   this.job     = null;
+  this.singleWorker = singleWorker || false;
+  if (this.singleWorker) {
+    this.locked = false;
+    this.lockKey = this.client.getKey(this.type);
+    this.lockTtl = lockTtl || 10000;
+    this.warlock = new Warlock(this.client);
+  }
 }
 
 /**
@@ -79,14 +88,62 @@ Worker.prototype.start = function( fn ) {
     }
   }.bind( this ));
 
-  self.getJob(function( err, job ) {
-    if( err ) self.error(err, job);
+  self.getJob(function (err, job ) {
+    if( err ) {
+      self.error(err, job);
+    }
     if( !job || err ) return process.nextTick(function() {
       self.start(fn);
     });
     self.process(job, fn);
   });
+
   return this;
+};
+
+/**
+ *
+ * Attempts to set the lock in redis for this worker.
+ * Second parameter of callback is true when the lock is successfully obtained
+ *
+ * @param  {Function} fn
+ */
+Worker.prototype.lock = function (fn) {
+  var self = this;
+  self.warlock.lock(self.lockKey, self.lockTtl, function (err, unlock) {
+    if (err) {
+      return fn(err);
+    }
+
+    if (typeof unlock === 'function') {
+      self.locked = true;
+      self.unlockFn = unlock;
+      fn(null, true);
+    } else {
+      fn(null, false);
+    }
+  });
+};
+
+/**
+ *
+ * Unlocks the worker if currently locked
+ *
+ * @param  {Function} fn
+ */
+Worker.prototype.unlock = function (fn) {
+  var self = this;
+  if (!fn) fn = noop;
+
+  if (!self.locked) {
+    return fn();
+  }
+
+  self.unlockFn(function(){
+    self.locked = false;
+    self.unlockFn = null;
+    fn();
+  });
 };
 
 /**
@@ -99,7 +156,11 @@ Worker.prototype.start = function( fn ) {
  */
 
 Worker.prototype.error = function( err, job ) {
+  var self = this;
   this.emit('error', err, job);
+  if (self.singleWorker) {
+    self.unlock();
+  }
   return this;
 };
 
@@ -155,42 +216,51 @@ Worker.prototype.process = function( job, fn ) {
    */
   var createDoneCallback = function( jobId ) {
     return function( err, result ) {
-      if( self.drop_user_callbacks ) {
-        //console.warn( 'Worker started to shutdown, ignoring execution of done callback' );
-        //job.log( 'Worker started to shutdown, ignoring execution of done callback' );
-        return;
-      }
-      /*
-      if no job in hand, or the current job in hand
-      doesn't match called done callback's jobId
-      then ignore running callers done.
-       */
-      if( self.job === null || self.job && self.job.id && self.job.id !== jobId ) {
-        //console.warn( 'This job has already been finished, ignoring execution of done callback' );
-        //job.log( 'This job has already been finished, ignoring execution of done callback' );
-        return;
-      }
-      if( err ) {
-        return self.failed(job, err, fn);
-      }
-      job.set('duration', job.duration = new Date - start);
-      if( result ) {
-        try {
-          job.result = result;
-          job.set('result', JSON.stringify(result), noop);
-        } catch(e) {
-          job.set('result', JSON.stringify({ error: true, message: 'Invalid JSON Result: "' + result + '"' }), noop);
+
+      var _finish = function () {
+        if( self.drop_user_callbacks ) {
+          //console.warn( 'Worker started to shutdown, ignoring execution of done callback' );
+          //job.log( 'Worker started to shutdown, ignoring execution of done callback' );
+          return;
         }
-      }
-      job.complete(function() {
-        job.attempt(function() {
-          if( job.removeOnComplete() ) {
-            job.remove();
+        /*
+        if no job in hand, or the current job in hand
+        doesn't match called done callback's jobId
+        then ignore running callers done.
+         */
+        if( self.job === null || self.job && self.job.id && self.job.id !== jobId ) {
+          //console.warn( 'This job has already been finished, ignoring execution of done callback' );
+          //job.log( 'This job has already been finished, ignoring execution of done callback' );
+          return;
+        }
+        if( err ) {
+          return self.failed(job, err, fn);
+        }
+        job.set('duration', job.duration = new Date - start);
+        if( result ) {
+          try {
+            job.result = result;
+            job.set('result', JSON.stringify(result), noop);
+          } catch(e) {
+            job.set('result', JSON.stringify({ error: true, message: 'Invalid JSON Result: "' + result + '"' }), noop);
           }
-          self.emitJobEvent('complete', job, result);
-          self.start(fn);
-        });
-      }.bind(this));
+        }
+        job.complete(function() {
+          job.attempt(function() {
+            if( job.removeOnComplete() ) {
+              job.remove();
+            }
+            self.emitJobEvent('complete', job, result);
+            self.start(fn);
+          });
+        }.bind(this));
+      };
+
+      if (!self.singleWorker) {
+        return _finish();
+      }
+
+      self.unlock(_finish);
     };
   };
 
@@ -273,15 +343,42 @@ Worker.prototype.getJob = function( fn ) {
       }
       return fn(err);		// SAE: Added to avoid crashing redis on zpop
     }
-    // Set job to a temp value so shutdown() knows to wait
-    self.job = true;
-    self.zpop(self.client.getKey('jobs:' + self.type + ':inactive'), function( err, id ) {
-      if( err || !id ) {
-        self.idle();
-        return fn(err /*|| "No job to pop!"*/);
+
+    var _getJob = function _getJob () {
+      // Set job to a temp value so shutdown() knows to wait
+      self.job = true;
+      self.zpop(self.client.getKey('jobs:' + self.type + ':inactive'), function( err, id ) {
+        if( err || !id ) {
+          self.idle();
+          if (self.singleWorker) {
+            return self.unlock(function () {
+              fn(err /*|| "No job to pop!"*/);
+            });
+          }
+          return fn(err /*|| "No job to pop!"*/);
+        }
+        Job.get(id, fn);
+      });
+    };
+
+    if (!self.singleWorker) {
+      return _getJob();
+    }
+
+    self.lock(function (err, success) {
+      if (err) {
+        self.client.lpush(self.client.getKey(self.type + ':jobs'), 1);
+        return fn(err);
       }
-      Job.get(id, fn);
+
+      if (!success) {
+        self.client.lpush(self.client.getKey(self.type + ':jobs'), 1);
+        return fn();
+      }
+
+      _getJob();
     });
+
   });
 };
 
@@ -316,6 +413,9 @@ Worker.prototype.shutdown = function( timeout, fn ) {
       return; // simply ignore older job events currently being received until the right one comes...
     }
     shutdownTimer && clearTimeout(shutdownTimer);
+    if (self.singleWorker) {
+      self.unlock();
+    }
     self.removeAllListeners();
     self.job        = null;
     //Safeyly kill any blpop's that are waiting.

--- a/test/redis_lock.js
+++ b/test/redis_lock.js
@@ -1,0 +1,77 @@
+(function () {
+  var kue = require('../'),
+      async = require('async'),
+      cluster = require('cluster'),
+      queue = kue.createQueue(),
+      redis = require('redis'),
+      client = redis.createClient(),
+      clusterSize = process.env.SIZE || 2, // require('os').cpus().length;
+      jobType = 'race';
+
+  if (cluster.isMaster) {
+    cleanup(function(){
+      for (var n = 0; n < 10; n++) {
+        queue.create(jobType, {
+          n: n
+        }).save();
+      }
+
+      cluster.on('exit', function (worker) {
+        for (var id in cluster.workers) {
+          // have to use .process.kill here
+          // https://github.com/nodejs/node-v0.x-archive/issues/5832#issuecomment-29224325
+          cluster.workers[id].process.kill();
+        }
+
+        cleanup(function() {
+          process.exit();
+        });
+      });
+
+      for (var i = 0; i < clusterSize; i++) {
+        cluster.fork();
+      }
+    });
+
+  } else {
+    process.once('SIGTERM', function () {
+      setTimeout(process.exit, 1000);
+    });
+
+    queue.process({
+      type: jobType,
+      singleWorker: true
+    }, function (job, done) {
+      var n = job.data.n;
+
+      console.log('Process ' + process.pid + ' is processing job: ' + n);
+
+      client.get('prev', function (err, prev) {
+        if (n && (n - Number(prev) !== 1)) {
+          console.error('FAIL');
+          done();
+          process.exit(1);
+        }
+
+        setTimeout(function () {
+          client.set('prev', n, done);
+          if (n === 9) {
+            console.log('Success!');
+            process.exit();
+          }
+        }, 1000);
+      });
+    });
+  }
+
+  function cleanup (cb) {
+    kue.Job.range(0, -1, 'asc', function (err, jobs) {
+      for (var i = 0; i < jobs.length; i++) {
+        if (jobs[i].type === jobType) {
+          jobs[i].remove();
+        }
+      }
+      cb();
+    });
+  }
+})();


### PR DESCRIPTION
Fixes #773 

This PR adds support for FIFO in a multiple server environment, where more than one server is processing the same job type. We have hundreds of job types specific to different customers that we work with, and we need jobs to be processed in order. With this PR, we can spread out the processing of the jobs across our few servers evenly, rather than having to choose which servers will process which job types. 

This PR contains changes that we've been using in our production environment since January with no issues.

By default, locking is not turned on, so this does not break existing behavior.

The `test/redis_lock.js` file is a script that we used when developing this solution, to test it in a simple way. The change does not lend itself to unit tests very well, and since there are no unit tests yet for `worker.js`, we decided to write a script that tests this directly in more of an integration test style. Happy to take it out of the PR, change it, whatever you think is best. 

I realize this may be a somewhat scary change. The diffs make it look worse than it actually is, but it still does touch some core functionality. I'm happy to discuss any questions/concerns/comments about the solution and work on making this something you feel comfortable merging. 
