### PR TITLE
Update travis conf to test against LTS, 5 branch and node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: node_js
 node_js:
   - "0.10"
   - "0.12"
-  - "4.2"
-  - "5.5"
+  - "4"
+  - "5"
+  - "node"
 services:
   - redis-server


### PR DESCRIPTION
I've modified the travis configuration so build happens against latest 0.10, 0.12, 4, node. 
Travis uses nvm to install node. Nvm will resolve latest version of those branches.
`node` is special, nvm will resolve the latest stable. Today it will be node v6.2.1.

