### PR TITLE
Add support for controlling job events at the job level

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -238,6 +238,12 @@ job.on('complete', function(result){
  kue.createQueue({jobEvents: false})
  ```
 
+ Alternatively, you can use the job level function `events` to control whether events are fired for a job at the job level.
+
+ ```js
+var job = queue.create('test').events(false).save();
+ ```
+
 ### Queue Events
 
 Queue-level events provide access to the job-level events previously mentioned, however scoped to the `Queue` instance to apply logic at a "global" level. An example of this is removing completed jobs:

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -290,6 +290,7 @@ function Job( type, data ) {
   this.type          = type;
   this.data          = data || {};
   this._max_attempts = 1;
+  this._jobEvents = exports.jobEvents;
 //  this.client = redis.client();
   this.client = Job.client/* || (Job.client = redis.client())*/;
   this.priority('normal');
@@ -448,6 +449,18 @@ Job.prototype.delay = function( ms ) {
   if( ms > 0 ) {
     this._delay = ms;
   }
+  return this;
+};
+
+/**
+ * Sets the jobEvents flag for the job.
+ * Can be used to override the global exports.jobEvents setting
+ *
+ * @param  {Boolean} events True if job events should be emitted, false if job events should not be emitted.
+ * @return {Job}        Returns `this` for chaining
+ */
+Job.prototype.events = function (events) {
+  this._jobEvents = !!events;
   return this;
 };
 
@@ -873,7 +886,7 @@ Job.prototype.update = function( fn ) {
  */
 
 Job.prototype.subscribe = function( callback ) {
-  if( exports.jobEvents ) {
+  if( this._jobEvents ) {
     events.add(this, callback);
   } else {
     callback && callback();


### PR DESCRIPTION
Fixes #610 

This PR adds support for overriding the global `jobEvents` setting on a per job basis. It adds a new function to the `Job` prototype called `events` which is simply passed a boolean. If `true`, job level events will be created for this job. If false, job level events will not be created for this job.

In the `.subscribe` function, we now check the job level setting to determine if we should emit events for the job.

The job level setting is `_jobEvents` and by default it inherits from the global setting `exports.jobEvents` in Job.js.