### PR TITLE
Remove unnecessary dependency to lodash-deep

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -17,8 +17,6 @@ var EventEmitter = require('events').EventEmitter
   , noop         = function() {
 };
 
-_.mixin(require('lodash-deep'));
-
 /**
  * Expose `Job`.
  */
@@ -865,7 +863,7 @@ Job.prototype.update = function( fn ) {
   if( !exports.disableSearch ) {
     if( this.searchKeys() ) {
       this.searchKeys().forEach(function( key ) {
-        var value = _.deepGetValue(this.data, key);
+        var value = _.get(this.data, key);
         if( !_.isString(value) ) {
           value = JSON.stringify(value);
         }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "body-parser": "^1.12.2",
     "express": "^4.12.2",
     "lodash": "^4.0.0",
-    "lodash-deep": "^2.0.0",
     "nib": "~1.1.2",
     "node-redis-warlock": "~0.2.0",
     "pug": "^2.0.0-beta3",


### PR DESCRIPTION
Full-text search is broken at least since https://github.com/Automattic/kue/pull/906, but there is no tests for that.

* `_.deepGetValue` had been renamed into `_.deepGet` in `lodash-deep 1.2.0` ([June 2014](https://github.com/marklagendijk/lodash-deep/pull/6)).
* `_.deepGet` has been dropped from `lodash-deep` as it's a native feature of `lodash 4.x` ([March 2016](https://github.com/marklagendijk/lodash-deep)).