### PR TITLE
Make reds an optional dependency

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -700,13 +700,17 @@ queue.create('email', {
 }).searchKeys( ['to', 'title'] ).save();
 ```
 
-Search feature is turned off by default from Kue `>=0.9.0`. Read more about this [here](https://github.com/Automattic/kue/issues/412). You should enable search indexes in you need to:
+Search feature is turned off by default from Kue `>=0.9.0`. Read more about this [here](https://github.com/Automattic/kue/issues/412). You should enable search indexes and add [reds](https://www.npmjs.com/package/reds) in your dependencies if you need to:
 
 ```javascript
 var kue = require('kue');
 q = kue.createQueue({
     disableSearch: false
 });
+```
+
+```
+npm install reds --save
 ```
 
 ### GET /stats

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -12,7 +12,6 @@
 var EventEmitter = require('events').EventEmitter
   , events       = require('./events')
   , redis        = require('../redis')
-  , reds         = require('reds')
   , _            = require('lodash')
   , util         = require('util')
   , noop         = function() {
@@ -38,6 +37,7 @@ exports.jobEvents = true;
 var search;
 function getSearch() {
   if( search ) return search;
+  var reds = require('reds');
   reds.createClient = require('../redis').createClient;
   return search = reds.createSearch(redis.client().getKey('search'));
 }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "chai": "^3.3.0",
     "coffee-script": "~1.10.0",
     "mocha": "^2.3.3",
+    "reds": "~0.2.5",
     "should": "^3.1.0",
     "sinon": "^1.17.2",
     "supertest": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "node-redis-warlock": "~0.2.0",
     "pug": "^2.0.0-beta3",
     "redis": "~2.6.0-2",
-    "reds": "~0.2.5",
     "stylus": "~0.52.4",
     "yargs": "^4.0.0"
   },


### PR DESCRIPTION
As full-text search is disabled by default, it seems a bit heavy to bundle `reds` as a required dependency.