### PR TITLE
Update packages to remove CVEs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,12 +29,12 @@
     "express": "^4.12.2",
     "lodash": "^4.0.0",
     "lodash-deep": "^2.0.0",
-    "nib": "~1.1.0",
+    "nib": "~1.1.2",
     "node-redis-warlock": "~0.2.0",
     "pug": "^2.0.0-beta3",
     "redis": "~2.6.0-2",
     "reds": "~0.2.5",
-    "stylus": "~0.52.4",
+    "stylus": "~0.54.5",
     "yargs": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently we have
```
$ nsp check --output summary
(+) 2 vulnerabilities found
 Name        Installed   Patched   Path                                                                     More Info
 minimatch   0.3.0       >=3.0.2   kue@0.11.1 > nib@1.1.0 > stylus@0.49.3 > glob@3.2.11 > minimatch@0.3.0   https://nodesecurity.io/advisories/118
 minimatch   0.3.0       >=3.0.2   kue@0.11.1 > stylus@0.52.4 > glob@3.2.11 > minimatch@0.3.0               https://nodesecurity.io/advisories/118
```

Updated `nib` and `stylus` to remove these CVEs.