### PR TITLE
FIX API comment states wrong default

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -132,7 +132,7 @@ Queue.prototype.on = function( event ) {
 
 /**
  * Promote delayed jobs, checking every `ms`,
- * defaulting to 5 seconds.
+ * defaulting to 1 second.
  *
  * @params {Number} ms
  * @deprecated
@@ -159,7 +159,7 @@ Queue.prototype.setupTimers = function() {
  * This new method is called by Kue when created
  *
  * Promote delayed jobs, checking every `ms`,
- * defaulting to 5 seconds.
+ * defaulting to 1 second.
  *
  * @params {Number} ms
  */


### PR DESCRIPTION
Comment said default was 5 seconds, but code says 1 second.

timeout      = promotionOptions.interval || 1000
...
this.promoter = setInterval(..., timeout)
