### PR TITLE
ISSUE-953 Fix redis commands SLC integration

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -337,7 +337,7 @@ Queue.prototype.process = function( type, n, fn ) {
     worker.on('job complete', function( job ) {
       // guard against emit after shutdown
       if( self.client ) {
-        self.client.incrby(self.client.getKey('stats:work-time'), job.duration);
+        self.client.incrby(self.client.getKey('stats:work-time'), job.duration, function () {});
       }
     });
     // Save worker so we can access it later

--- a/lib/queue/events.js
+++ b/lib/queue/events.js
@@ -130,5 +130,5 @@ exports.emit = function( id, event ) {
     , msg    = JSON.stringify({
         id: id, event: event, args: [].slice.call(arguments, 1)
       });
-  client.publish(client.getKey(exports.key), msg);
+  client.publish(client.getKey(exports.key), msg, function () {});
 };

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -791,13 +791,12 @@ Job.prototype.save = function( fn ) {
   client.incr(client.getKey('ids'), function( err, id ) {
     if( err ) return fn(err);
     // add the job for event mapping
-    var key = client.getKey('job:' + id);
     self.id = id;
     self.zid = client.createFIFO(id);
     self.subscribe(function() {
       self._state     = self._state || (this._delay ? 'delayed' : 'inactive');
-      if( max ) client.hset(key, 'max_attempts', max);
-      client.sadd(client.getKey('job:types'), self.type);
+      if( max ) { self.set('max_attempts', max); }
+      client.sadd(client.getKey('job:types'), self.type, noop);
       self.set('type', self.type);
       var now         = Date.now();
       self.created_at = now;
@@ -854,7 +853,7 @@ Job.prototype.update = function( fn ) {
   // priority
   this.set('priority', this._priority);
 
-  this.client.zadd(this.client.getKey('jobs'), this._priority, this.zid);
+  this.client.zadd(this.client.getKey('jobs'), this._priority, this.zid, noop);
 
   // data
   this.set('data', json, function() {


### PR DESCRIPTION
The tool that is buggy is [`strong-agent`](https://www.npmjs.com/package/strong-agent), which is no longer open source.
The NPM version is **2.1.0**, and the old [github](https://github.com/strongloop/strong-agent) version is stuck at **2.0.1**.
A bug was raised for this: https://github.com/strongloop/strong-agent/issues/10.

The `strong-agent` redis wrapper is more demanding than the actual redis client used by kue.
That is why we are enforcing all the relevant — by *relevant* we mean those that break at a simple HTTP request to register a job and are known to us — redis calls done by kue to respect the requirements of the `strong-agent` redis wrapper.

Fixes https://github.com/Automattic/kue/issues/953.