### PR TITLE
Add delay to custom back off function

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -148,6 +148,8 @@ Job retry attempts are done as soon as they fail, with no delay, even if your jo
 
     // Use a function to get a customized next attempt delay value
     job.attempts(3).backoff( function( attempts, delay ){
+      //attempts will correspond to the nth attempt failure so it will start with 0
+      //delay will be the amount of the last delay, not the initial delay unless attempts === 0
       return my_customized_calculated_delay;
     })
 ```

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -569,7 +569,7 @@ Job.prototype.reattempt = function( attempts, clbk ) {
     var delay = this.delay();
     if( _.isFunction(this._getBackoffImpl()) ) {
       try {
-        delay = this._getBackoffImpl().apply(this, [ attempts ]);
+        delay = this._getBackoffImpl().apply(this, [ attempts, delay ]);
       } catch(e) {
         clbk(e);
       }

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -290,7 +290,7 @@ describe 'Kue Tests', ->
       [total, remaining] = [2,2]
       start = Date.now()
       jobs.create( 'backoff-user-job', { title: 'backoff-user-job' } )
-      .delay( 50 ).attempts(total).backoff( ( attempts ) -> 250 ).save()
+      .delay( 50 ).attempts(total).backoff( ( attempts, delay ) -> 250 ).save()
       jobs.process 'backoff-user-job', (job, jdone) ->
         now = Date.now()
         if( !--remaining )


### PR DESCRIPTION
The docs had delay being supplied to custom backoff functions. It was not actually being applied, also updated the readme with more details about how custom backoff functions work.  