### PR TITLE
add id param validation in Job.get() to prevent uncaught exception

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -159,6 +159,9 @@ exports.rangeByType = function( type, state, from, to, order, fn ) {
  */
 
 exports.get = function( id, jobType, fn ) {
+  if (id === null || id === undefined) {
+    return fn(new Error('invalid id param'));
+  }
   if (typeof jobType === 'function' && !fn) {
     fn = jobType;
     jobType = '';


### PR DESCRIPTION
issue #989 - calling `Job.get()` with an `id` param that is null or undefined will result in an uncaught exception.

this adds a validation check to prevent this, and returns an application level error instead