### PR TITLE
Allow override of promotion lockTtl

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -169,7 +169,7 @@ Queue.prototype.checkJobPromotion = function( promotionOptions ) {
   var client       = this.client
     , self         = this
     , timeout      = promotionOptions.interval || 1000
-    , lockTtl      = 2000
+    , lockTtl      = promotionOptions.lockTtl || 2000
       //, lockTtl = timeout
     , limit        = promotionOptions.limit || 1000;
   clearInterval(this.promoter);

--- a/test/tdd/kue.spec.js
+++ b/test/tdd/kue.spec.js
@@ -152,7 +152,13 @@ describe('Kue', function () {
     it('should set the promotion lock', function () {
       queue.checkJobPromotion();
       clock.tick(timeout);
-      queue.warlock.lock.calledWith('promotion').should.be.true;
+      queue.warlock.lock.calledWith('promotion', 2000).should.be.true;
+    });
+
+    it('should allow an override for the lockTtl', function () {
+      queue.checkJobPromotion({ lockTtl: 5000 });
+      clock.tick(timeout);
+      queue.warlock.lock.calledWith('promotion', 5000).should.be.true;
     });
 
     it('should load all delayed jobs that should be run job', function () {


### PR DESCRIPTION
Fixes #971 

This PR enables the user to override the default lock promotion ttl of 2 seconds to whatever they want. To use it, the user simply passes a promotion option when creating the kue instance.

```js
kue.createQueue({
  promotion: {
    lockTtl: 5000
  }
});
```