### PR TITLE
Minor formatting of readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -194,14 +194,14 @@ data can be used to pass extra information about the job. For example a message 
 
 Job-specific events are fired on the `Job` instances via Redis pubsub. The following events are currently supported:
 
-    - `enqueue` the job is now queued
-    - `start` the job is now running
-    - `promotion` the job is promoted from delayed state to queued
-    - `progress` the job's progress ranging from 0-100
-    - `failed attempt` the job has failed, but has remaining attempts yet
-    - `failed` the job has failed and has no remaining attempts
-    - `complete` the job has completed
-    - `remove` the job has been removed
+- `enqueue` the job is now queued
+- `start` the job is now running
+- `promotion` the job is promoted from delayed state to queued
+- `progress` the job's progress ranging from 0-100
+- `failed attempt` the job has failed, but has remaining attempts yet
+- `failed` the job has failed and has no remaining attempts
+- `complete` the job has completed
+- `remove` the job has been removed
 
 
 For example this may look something like the following:


### PR DESCRIPTION
Render Job Event listing as a list instead of as a block of code.

(i suspect this was the original intention)
