### PR TITLE
add prefix as a parameter for kue-dashboard

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -646,10 +646,10 @@ var queue = kue.createQueue({
 
 The UI is a small [Express](https://github.com/strongloop/express) application.
 A script is provided in `bin/` for running the interface as a standalone application
-with default settings. You may pass in options for the port and redis-url. For example:
+with default settings. You may pass in options for the port, redis-url, and prefix. For example:
 
 ```
-node_modules/kue/bin/kue-dashboard -p 3050 -r redis://127.0.0.1:3000
+node_modules/kue/bin/kue-dashboard -p 3050 -r redis://127.0.0.1:3000 -q prefix
 ```
 
 You can fire it up from within another application too:

--- a/bin/kue-dashboard
+++ b/bin/kue-dashboard
@@ -2,18 +2,21 @@
 var kue = require('kue');
 var argv = require('yargs')
 	.usage('Usage: $0 [options]')
-	.example('$0 -p 3050 -r redis://10.0.0.4:6379')
+	.example('$0 -p 3050 -r redis://10.0.0.4:6379 -q q')
 	.describe('r', 'Redis url')
 	.describe('p', 'Dashboard port')
+	.describe('q', 'Prefix to use')
 	.default('p', 3000)
 	.default('r', 'redis://127.0.0.1:6379')
+	.default('q', 'q')
 	.help('h')
     .alias('h', 'help')
     .argv
 ;
 
 kue.createQueue({
-  redis: argv.r
+  redis: argv.r,
+  prefix: argv.q
 });
 
 


### PR DESCRIPTION
As is, `kue-dashboard` only lets you view the default queue (prefix of 'q'), this adds it as an optional param.