### PR TITLE
Allow exponential backoff to cap its delay at an specified maximum

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -491,6 +491,7 @@ Job.prototype.ttl = function( param ) {
 };
 
 Job.prototype._getBackoffImpl = function() {
+  var self = this
   var supported_backoffs = {
     fixed: function( delay ) {
       return function( attempts ) {
@@ -499,7 +500,10 @@ Job.prototype._getBackoffImpl = function() {
     }
     , exponential: function( delay ) {
       return function( attempts ) {
-        return Math.round(delay * 0.5 * ( Math.pow(2, attempts) - 1));
+        return Math.round(Math.min(
+          (self._backoff.maxDelay || Infinity) - (delay * 0.5),
+          delay * 0.5 * ( Math.pow(2, attempts) - 1)
+        ));
       };
     }
   };

--- a/test/test.coffee
+++ b/test/test.coffee
@@ -284,6 +284,23 @@ describe 'Kue Tests', ->
         else
           jdone( new Error('reaattempt') )
 
+    it 'should honor max delay at exponential backoff', (done) ->
+      [total, remaining] = [10,10]
+      last = Date.now()
+      jobs.create( 'backoff-exponential-job', { title: 'backoff-exponential-job' } )
+      .attempts(total).backoff( {type:'exponential', delay: 50, maxDelay: 100} ).save()
+      jobs.process 'backoff-exponential-job', (job, jdone) ->
+        job._backoff.type.should.be.equal "exponential"
+        job._backoff.delay.should.be.equal 50
+        job._backoff.maxDelay.should.be.equal 100
+        now = Date.now()
+        (now - last).should.be.lessThan 120
+        if( !--remaining )
+          jdone()
+          done()
+        else
+          last = now
+          jdone( new Error('reaattempt') )
 
 
     it 'should honor users backoff function', (done) ->


### PR DESCRIPTION
Allows a new argument in the backoff object, `maxDelay`, which caps the delay that a failed attempt will have when using exponential backoff.

Fixes #1025