### PR TITLE
Kue poll

### DIFF
--- a/lib/http/public/javascripts/main.js
+++ b/lib/http/public/javascripts/main.js
@@ -143,7 +143,7 @@ function show(state) {
         o('#jobs .job').remove();
         o('#menu li a').removeClass('active');
         o('#menu li.' + state + ' a').addClass('active');
-        pollForJobs(state, 10000);
+        pollForJobs(state, 2000);
         return false;
     }
 }

--- a/lib/http/public/javascripts/main.js
+++ b/lib/http/public/javascripts/main.js
@@ -143,7 +143,7 @@ function show(state) {
         o('#jobs .job').remove();
         o('#menu li a').removeClass('active');
         o('#menu li.' + state + ' a').addClass('active');
-        pollForJobs(state, 1000);
+        pollForJobs(state, 10000);
         return false;
     }
 }


### PR DESCRIPTION
Increasing the poll interval to 2s to ameliorate the risk of a dashboard crash.  The dashboard becomes markedly less usable with longer intervals, so trying to be conservative.  It's a bit hard to test whether this would actually solve our problems -- we don't have payloads on the order Baptist flowing through 10x right now.