### PR TITLE
Fix for issue #1061

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -99,7 +99,7 @@ var job = queue.create('email', {
 
 ### Job Priority
 
-To specify the priority of a job, simply invoke the `priority()` method with a number, or priority name, which is mapped to a number.
+To specify the priority of a job, simply invoke the `priority()` method with a number (the lower the number the higher the priority), or priority name, which is mapped to a number.
 
 ```js
 queue.create('email', {

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -42,7 +42,8 @@ function getSearch() {
 /**
  * Default job priority map.
  */
-
+var minPriority = exports.minPriority = -15
+var maxPriority = exports.maxPriority = 10
 var priorities = exports.priorities = {
   low: 10, normal: 0, medium: -5, high: -10, critical: -15
 };
@@ -517,7 +518,8 @@ Job.prototype._getBackoffImpl = function() {
 /**
  * Set or get the priority `level`, which is one
  * of "low", "normal", "medium", and "high", or
- * a number in the range of -10..10.
+ * a number in the range of -15..10 where -15
+ * is the highest priority and 10 is the lowest.
  *
  * @param {String|Number} level
  * @return {Job|Number} for chaining
@@ -526,9 +528,18 @@ Job.prototype._getBackoffImpl = function() {
 
 Job.prototype.priority = function( level ) {
   if( 0 == arguments.length ) return this._priority;
-  this._priority = null == priorities[ level ]
-    ? level
-    : priorities[ level ];
+  if( typeof level === 'number' ){
+    if( minPriority <= level && level <= maxPriority ) {
+      this._priority =level
+    } else {
+      throw new Error('Priority: ' + level + ' is not in the range ' + minPriority + ' to ' + maxPriority)
+    }
+  } else if( priorities[level] !== undefined ) {
+    this._priority = priorities[level]
+  } else {
+    throw new Error('Priority is ' + level +
+      ' but it must be either a number or a string from the "low", "nowmal", "medium", "high" or critical')
+  }
   return this;
 };
 

--- a/test/tdd/job.spec.js
+++ b/test/tdd/job.spec.js
@@ -1,0 +1,58 @@
+var sinon = require('sinon');
+var kue = require('../../lib/kue');
+var Job = require('../../lib/queue/job');
+var Worker = require('../../lib/queue/worker');
+var _ = require('lodash');
+
+describe('Job', function () {
+  var queue = null;
+  var job = null;
+
+  beforeEach(function () {
+    queue = kue.createQueue({promotion:{interval:50}});
+    job = queue.create('test-job')
+  });
+
+  afterEach(function (done) {
+    queue.shutdown(50, done);
+  });
+
+  describe('Funtion: create', function () {
+
+    it('should have priority normal by default', function () {
+      job._priority.should.be = Job.priorities['normal'];
+    })
+
+  });
+
+  describe('Function: priority', function () {
+
+    it('should be settable for all numbers in range ' + Job.minPriority + ' to ' + Job.maxPriority, function () {
+      for(var i = Job.minPriority; i <= Job.maxPriority; i++){
+        job.priority(i);
+        job._priority.should.be = i;
+      }
+    })
+
+    it('should be settable for all values in priority map', function () {
+      for(var prio in Job.priorities){
+        job.priority(prio);
+        job._priority.should.be = Job.priorities[prio];
+      }
+    })
+
+    it('should throw error if level is out of range', function () {
+      (() => {job.priority(Job.minPriority - 1)}).should.throw();
+      (() => {job.priority(Job.maxPriority + 1)}).should.throw();
+    })
+
+    it('should throw error if level is not a number and not an member of Job.priorities', function () {
+      (() => {job.priority('acbd1234')}).should.throw();
+      (() => {job.priority(undefined)}).should.throw();
+      (() => {job.priority(null)}).should.throw();
+    })
+
+
+  });
+
+});


### PR DESCRIPTION
`Job.prototype.priority(level)` will now only set the priority
if `level` is a number between of `Job.minPriority` and `Job.maxPriority`
or the name of one of the variables in `Job.priorities`.
Otherwise an `Error` will be thrown.

I also created a new test file for the Job class. I couldn't really find
any other place to put the tests that made sense.

I also enforced and defined the maximum and minimum priorities to limit the number
of magic numbers.