### PR TITLE
fix(filter): Encode URI when using filter

### DIFF
--- a/lib/http/public/javascripts/main.js
+++ b/lib/http/public/javascripts/main.js
@@ -181,7 +181,7 @@ function refreshJobs(state, fn) {
         , visibleFrom = Math.max(0, Math.floor(top / jobHeight))
         , visibleTo = Math.floor((top + height) / jobHeight)
         , url = './jobs/'
-            + (filter ? filter + '/' : '')
+            + (filter ? encodeURIComponent(filter) + '/' : '')
             + state + '/0..' + to
             + '/' + sort;
 


### PR DESCRIPTION
I'm using `/` in the job type, but filtering is not working because constructed URL has bad format:
`http://localhost/kue/api/jobs/person/welcome/complete/0..10/asc` but it should be `http://localhost/kue/api/jobs/person%2Fwelcome/complete/0..10/asc`.

This can be fixed by using `encodeURIComponent` on filter value.