### PR TITLE
#1081 convert job date fields to numbers when job loaded

### DIFF
--- a/lib/http/public/javascripts/job.js
+++ b/lib/http/public/javascripts/job.js
@@ -220,8 +220,8 @@ Job.prototype.renderUpdate = function () {
 
     // delayed
     if ('delayed' == this.state) {
-        var delay = parseInt(this.delay, 10)
-            , creation = parseInt(this.created_at, 10)
+        var delay = this.delay
+            , creation = this.created_at
             , remaining = relative(creation + delay - Date.now());
         view.title((this.data.title || '') + ' <em>( ' + remaining + ' )</em>');
     }

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -185,18 +185,18 @@ exports.get = function( id, jobType, fn ) {
     // we can just merge these
     job.type              = hash.type;
     job._ttl              = hash.ttl;
-    job._delay            = hash.delay;
+    job._delay            = parseInt(hash.delay, 10);
     job.priority(Number(hash.priority));
     job._progress         = hash.progress;
     job._attempts         = Number(hash.attempts);
     job._max_attempts     = Number(hash.max_attempts);
     job._state            = hash.state;
     job._error            = hash.error;
-    job.created_at        = hash.created_at;
-    job.promote_at        = hash.promote_at;
-    job.updated_at        = hash.updated_at;
-    job.failed_at         = hash.failed_at;
-    job.started_at        = hash.started_at;
+    job.created_at        = parseInt(hash.created_at, 10);
+    job.promote_at        = parseInt(hash.promote_at, 10);
+    job.updated_at        = parseInt(hash.updated_at, 10);
+    job.failed_at         = parseInt(hash.failed_at, 10);
+    job.started_at        = parseInt(hash.started_at, 10);
     job.duration          = hash.duration;
     job.workerId          = hash.workerId;
     job._removeOnComplete = hash.removeOnComplete;
@@ -692,7 +692,7 @@ Job.prototype.state = function( state, fn ) {
     .zadd(client.getKey('jobs:' + this.type + ':' + state), this._priority, this.zid);
 
   // use promote_at as score when job moves to delayed
-  ('delayed' === state) ? multi.zadd(client.getKey('jobs:' + state), parseInt(this.promote_at), this.zid) : noop();
+  ('delayed' === state) ? multi.zadd(client.getKey('jobs:' + state), this.promote_at, this.zid) : noop();
   ('active' === state && this._ttl > 0) ? multi.zadd(client.getKey('jobs:' + state), Date.now() + parseInt(this._ttl), this.zid) : noop();
   ('active' === state && !this._ttl) ? multi.zadd(client.getKey('jobs:' + state), this._priority<0?this._priority:-this._priority, this.zid) : noop();
   ('inactive' === state) ? multi.lpush(client.getKey(this.type + ':jobs'), 1) : noop();
@@ -839,8 +839,8 @@ Job.prototype.update = function( fn ) {
   if( this._delay ) {
     this.set('delay', this._delay);
     if( this.created_at ) {
-      var timestamp   = parseInt(this.failed_at || this.created_at, 10)
-        , delay       = parseInt(this._delay);
+      var timestamp   = this.failed_at || this.created_at
+        , delay       = this._delay;
       this.promote_at = timestamp + delay;
       this.set('promote_at', this.promote_at);
     }


### PR DESCRIPTION
Some job fields are date values. When a job is loaded from redis, all fields are strings. In order to make it consistent, all date fields are converted to numbers.