### PR TITLE
Fix for the case of giving erroneous value to {id} and function value…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ node_modules
 *.rdb
 test/incomplete
 *.swp
+yarn.lock

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -159,12 +159,12 @@ exports.rangeByType = function( type, state, from, to, order, fn ) {
  */
 
 exports.get = function( id, jobType, fn ) {
-  if (id === null || id === undefined) {
-    return fn(new Error('invalid id param'));
-  }
   if (typeof jobType === 'function' && !fn) {
     fn = jobType;
     jobType = '';
+  }
+  if (id === null || id === undefined) {
+    return fn(new Error('invalid id param'));
   }
   var client = redis.client()
     , job    = new Job;


### PR DESCRIPTION
For the case of calling the 

> Job.get(undefined,()=>{})

It will raise an exception as the id's error is sent back by the non-determined third argument which is undefined.

The fix provides the correct order of argument validation inside the considered  function.