### PR TITLE
Implemented a hook function to be called before any jobs promotion, t…

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -172,9 +172,11 @@ Queue.prototype.checkJobPromotion = function( promotionOptions ) {
     , timeout      = promotionOptions.interval || 1000
     , lockTtl      = promotionOptions.lockTtl || 2000
       //, lockTtl = timeout
-    , limit        = promotionOptions.limit || 1000;
+    , limit        = promotionOptions.limit || 1000
+    , postpone     = promotionOptions.postpone || function() { return false };
   clearInterval(this.promoter);
   this.promoter    = setInterval(function() {
+    if ( postpone() ) return;
     self.warlock.lock('promotion', lockTtl, function( err, unlock ) {
       if( err ) {
         // Something went wrong and we weren't able to set a lock

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -179,7 +179,7 @@ exports.get = function( id, jobType, fn ) {
     }
     if( !hash.type ) {
       exports.removeBadJob(job.id, jobType);
-      return fn(new Error('job "' + job.id + '" is invalid'))
+      return fn(new Error('job "' + job.id + '" is invalid: ' + JSON.stringify(hash)))
     }
     // TODO: really lame, change some methods so
     // we can just merge these


### PR DESCRIPTION
…o postpone a promotion if necessary (if true returned). Use case for this function, for example, is to check if worker node is hitting upper memory limit, and prevent Kue from grabbing new jobs for promotion.