### PR TITLE
Global hook to determine ...

### DIFF
--- a/lib/queue/worker.js
+++ b/lib/queue/worker.js
@@ -43,6 +43,8 @@ function Worker( queue, type ) {
   this.client  = Worker.client || (Worker.client = redis.createClient());
   this.running = true;
   this.job     = null;
+  this.allowFetch = (queue && queue._options && queue._options.allowFetchJobs && typeof queue._options.allowFetchJobs === 'function') ?
+      queue._options.allowFetchJobs : function() { return true };
 }
 
 /**
@@ -267,6 +269,9 @@ Worker.prototype.getJob = function( fn ) {
   var self = this;
   if( !self.running ) {
     return fn('Already Shutdown');
+  }
+  if ( !self.allowFetch(self.type) ) {
+    return fn(null, null);
   }
   // alloc a client for this job type
   var client = clients[ self.type ] || (clients[ self.type ] = redis.createClient());


### PR DESCRIPTION
... if Workers are allowed to fetch new jobs from Redis for execution. Hook function can be set up with kue.createQueue (through options object):

let kuePaused = true;
const kueAllowFetchNewJobs = function(jobType: string) {
    const memoryUsageMB = {rss: 0, heapTotal: 0, heapUsed: 0, external: 0, ...process.memoryUsage()};
    memoryUsageMB.rss = Math.round(memoryUsageMB.rss/1024/1024);
    memoryUsageMB.heapTotal = Math.round(memoryUsageMB.heapTotal/1024/1024);
    memoryUsageMB.heapUsed = Math.round(memoryUsageMB.heapUsed/1024/1024);
    memoryUsageMB.external = Math.round(memoryUsageMB.external/1024/1024);
    const pause = kuePaused || (Math.max(memoryUsageMB.rss, memoryUsageMB.heapTotal) + memoryUsageMB.external) >= (MEMORY_AVAILABLE_MB - 60);
    return !pause;
};

const q = kue.createQueue({
    allowFetchJobs: kueAllowFetchNewJobs
});

Hook function should return true, if fetching new jobs is allowed, and false to prevent Kue from fetching new jobs.

Possible use case is to prevent Kue from grabbing new jobs for execution globally (for all job types or for a certain job type), if JS node is hitting upper memory limit, or if it's too much CPU used. With this feature, balancers can be implemented for better control over stability and scalability of a Kue-based application between many nodes, sharing same Redis.