### PR TITLE
Add custom ids

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -818,6 +818,28 @@ Job.prototype.save = function( fn ) {
 };
 
 /**
+ * Create the job and callback `fn(err)`.
+ *
+ * @param {Function} fn
+ * @api public
+ */
+
+Job.prototype.create = function( fn ) {
+  var client = this.client
+    , max    = this._max_attempts;
+  this._state     = this._state || (this._delay ? 'delayed' : 'inactive');
+  if( max ) { this.set('max_attempts', max); }
+  client.sadd(client.getKey('job:types'), this.type, noop);
+  this.set('type', this.type);
+  var now         = Date.now();
+  this.created_at = now;
+  this.set('created_at', this.created_at);
+  this.promote_at = now + (this._delay || 0);
+  this.set('promote_at', this.promote_at);
+  this.update(fn);
+}
+
+/**
  * Update the job and callback `fn(err)`.
  *
  * @param {Function} fn

--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -789,31 +789,31 @@ Job.prototype.delayed = function( clbk ) {
 Job.prototype.save = function( fn ) {
   var client = this.client
     , fn     = fn || noop
-    , max    = this._max_attempts
     , self   = this;
 
   // update
   if( this.id ) return this.update(fn);
 
-  // incr id
-  client.incr(client.getKey('ids'), function( err, id ) {
-    if( err ) return fn(err);
-    // add the job for event mapping
-    self.id = id;
-    self.zid = client.createFIFO(id);
-    self.subscribe(function() {
-      self._state     = self._state || (this._delay ? 'delayed' : 'inactive');
-      if( max ) { self.set('max_attempts', max); }
-      client.sadd(client.getKey('job:types'), self.type, noop);
-      self.set('type', self.type);
-      var now         = Date.now();
-      self.created_at = now;
-      self.set('created_at', self.created_at);
-      self.promote_at = now + (self._delay || 0);
-      self.set('promote_at', self.promote_at);
-      self.update(fn);
+  if (client.idFunction) {
+      // add the job for event mapping
+      var id = client.idFunction();
+      self.id = id;
+      self.zid = client.createFIFO(id);
+      self.subscribe(function() {
+        self.create(fn);
+      }.bind(this));
+  } else {
+    // incr id
+    client.incr(client.getKey('ids'), function( err, id ) {
+      if( err ) return fn(err);
+      // add the job for event mapping
+      self.id = id;
+      self.zid = client.createFIFO(id);
+      self.subscribe(function() {
+        self.create(fn);
+      }.bind(this));
     }.bind(this));
-  }.bind(this));
+  }
   return this;
 };
 

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -20,7 +20,8 @@ var url   = require('url');
  */
 
 exports.configureFactory = function( options, queue ) {
-  options.prefix = options.prefix || 'q';
+  options.prefix     = options.prefix || 'q';
+  options.idFunction = options.idFunction;
 
   if( typeof options.redis === 'string' ) {
     // parse the url

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -22,6 +22,7 @@ var url   = require('url');
 exports.configureFactory = function( options, queue ) {
   options.prefix     = options.prefix || 'q';
   options.idFunction = options.idFunction;
+  options.idType     = options.idType || 'number';
 
   if( typeof options.redis === 'string' ) {
     // parse the url
@@ -68,6 +69,7 @@ exports.configureFactory = function( options, queue ) {
 
     client.prefix           = options.prefix;
     client.idFunction       = options.idFunction;
+    client.idType           = options.idType;
 
     // redefine getKey to use the configured prefix
     client.getKey = function( key ) {
@@ -90,7 +92,13 @@ exports.configureFactory = function( options, queue ) {
     // Parse out original ID from zid
     client.stripFIFO = function( zid ) {
       if ( zid.includes('|') ) {
-        return zid.substr(zid.indexOf('|')+1);
+        switch ( client.idType ) {
+          case 'string': 
+          return zid.substr(zid.indexOf('|')+1);
+          case 'number':
+          default:
+            return +zid.substr(zid.indexOf('|')+1);
+        }
       } else {
         // Sometimes this gets called with an undefined
         // it seems to be OK to have that not resolve to an id

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -87,8 +87,8 @@ exports.configureFactory = function( options, queue ) {
 
     // Parse out original ID from zid
     client.stripFIFO = function( zid ) {
-      if ( typeof zid === 'string' ) {
-        return +zid.substr(zid.indexOf('|')+1);
+      if ( zid.includes('|') ) {
+        return zid.substr(zid.indexOf('|')+1);
       } else {
         // Sometimes this gets called with an undefined
         // it seems to be OK to have that not resolve to an id

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -67,6 +67,7 @@ exports.configureFactory = function( options, queue ) {
     });
 
     client.prefix           = options.prefix;
+    client.idFunction       = options.idFunction;
 
     // redefine getKey to use the configured prefix
     client.getKey = function( key ) {

--- a/test/tdd/redis.spec.js
+++ b/test/tdd/redis.spec.js
@@ -105,10 +105,17 @@ describe('redis', function() {
 
     describe('Function: client.stripFIFO', function() {
 
-      it('should strip the prefix on the id', function () {
+      it('should strip the prefix on a number id', function () {
         var client = redis.createClient();
         var id = client.stripFIFO( '03|123' );
         id.should.equal(123);
+      });
+
+      it('should strip the prefix on a string id', function () {
+        var client = redis.createClient();
+        client.idType = 'string';
+        var id = client.stripFIFO( '03|abc-def-ghi' );
+        id.should.equal('abc-def-ghi');
       });
     });
 


### PR DESCRIPTION
Resolves issue #1126 by adding the functionality to enable custom ids, such as string uuids or your own custom id generation function.

Have added two new options to the config:
- `idFunction` - a function returning the new id
- `idType` - the type of the id (string or number)