### PR TITLE
Update .travis.yaml - test platforms by node LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: node_js
 node_js:
-  - "0.10"
-  - "0.12"
   - "4"
   - "5"
+  - "6"
+  - "7"
   - "node"
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: node_js
 node_js:
   - "4"
-  - "5"
   - "6"
-  - "7"
   - "8"
   - "node"
 services:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
   - "5"
   - "6"
   - "7"
+  - "8"
   - "node"
 services:
   - redis-server


### PR DESCRIPTION
the lower versions of node fail because of dependencies.
The dependencies moved forward - so should we.