### PR TITLE
enable cors

### DIFF
--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -20,7 +20,8 @@ var app        = express()
   , pug       = require('pug')
   , json       = require('./routes/json')
   , util       = require('util')
-  , nib        = require('nib');
+  , nib        = require('nib')
+  , cors       = require('cors');
 
 // expose the app
 
@@ -47,6 +48,7 @@ app.locals     = { inspect: util.inspect };
 
 app.use(stylus.middleware({ src: __dirname + '/public', compile: compile }));
 app.use(express.static(__dirname + '/public'));
+app.use('*', cors());
 
 // JSON api
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "body-parser": "^1.12.2",
+    "cors": "^2.8.4",
     "express": "^4.12.2",
     "lodash": "^4.0.0",
     "nib": "~1.1.2",


### PR DESCRIPTION
This PR is for enabling cors by default. Useful for using the JSON-API from external JS applications.