### PR TITLE
Sort job types before rendering into select view

### DIFF
--- a/lib/http/routes/index.js
+++ b/lib/http/routes/index.js
@@ -20,7 +20,7 @@ exports.jobs = function( state ) {
   return function( req, res ) {
     queue.types(function( err, types ) {
       res.render('job/list', {
-        state: state, types: types, title: req.app.get('title')
+        state: state, types: types.sort(), title: req.app.get('title')
       });
     });
   };


### PR DESCRIPTION
When there are hundreds of job types, this makes the gnarly select options easier on the eyes and somewhat manageable.

:)