### PR TITLE
swap jobType and fn before validating id in job.get

### DIFF
--- a/lib/queue/job.js
+++ b/lib/queue/job.js
@@ -159,12 +159,13 @@ exports.rangeByType = function( type, state, from, to, order, fn ) {
  */
 
 exports.get = function( id, jobType, fn ) {
-  if (id === null || id === undefined) {
-    return fn(new Error('invalid id param'));
-  }
   if (typeof jobType === 'function' && !fn) {
     fn = jobType;
     jobType = '';
+  }  
+  
+  if (id === null || id === undefined) {
+    return fn(new Error('invalid id param'));
   }
   var client = redis.client()
     , job    = new Job;


### PR DESCRIPTION
I mistakenly passed undefined as id and my 2nd param was function and I was getting:
`TypeError: fn is not a function1`

Instead, It should have shown `invalid id param`.