### PR TITLE
Save/Update test-replacements return Job-Object

### DIFF
--- a/lib/queue/test_mode.js
+++ b/lib/queue/test_mode.js
@@ -9,7 +9,7 @@ var originalJobSave   = Job.prototype.save,
 function testJobSave( fn ) {
   if(processQueue) {
     jobs.push(this);
-    originalJobSave.call(this, fn);
+    return originalJobSave.call(this, fn);
   } else {
     this.id = _.uniqueId();
     jobs.push(this);
@@ -19,7 +19,7 @@ function testJobSave( fn ) {
 
 function testJobUpdate( fn ) {
   if(processQueue) {
-    originalJobUpdate.call(this, fn);
+    return originalJobUpdate.call(this, fn);
   } else {
     if( _.isFunction(fn) ) fn();
   }


### PR DESCRIPTION
In testmode with enabled processing the original save/update method of the Job-object gets called, but the result gets not returned.
Therefore `save()` and `update()` would return `undefined` rather then the Job-object.