### PR TITLE
pass redis options through, rather than attempt to parse them

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -584,11 +584,7 @@ var kue = require('kue');
 var q = kue.createQueue({
   prefix: 'q',
   redis: {
-    socket: '/data/sockets/redis.sock',
-    auth: 'password',
-    options: {
-      // see https://github.com/mranney/node_redis#rediscreateclient
-    }
+    // see https://github.com/mranney/node_redis#rediscreateclient for options
   }
 });
 ```

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -96,8 +96,10 @@ exports.configureFactory = function( options, queue ) {
  */
 
 exports.createClientFactory = function( options ) {
-  var socket = options.redis.socket;
-  return redis.createClient(socket || options.redis);
+  // socket used to be passed in explicitly as an option
+  // convert it to how the redis client is looking for it sees it if present.
+  options.path = options.redis.socket;
+  return redis.createClient(options.redis);
 };
 
 /**

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -23,24 +23,12 @@ exports.configureFactory = function( options, queue ) {
   options.prefix = options.prefix || 'q';
 
   if( typeof options.redis === 'string' ) {
-    // parse the url
-    var conn_info = url.parse(options.redis, true /* parse query string */);
-    if( conn_info.protocol !== 'redis:' ) {
-      throw new Error('kue connection string must use the redis: protocol');
-    }
+    options.redis = { url: options.redis }
+  }
 
-    options.redis = {
-      port: conn_info.port || 6379,
-      host: conn_info.hostname,
-      db: (conn_info.pathname ? conn_info.pathname.substr(1) : null) || conn_info.query.db || 0,
-      // see https://github.com/mranney/node_redis#rediscreateclient
-      options: conn_info.query
-    };
-
-    if( conn_info.auth ) {
-      options.redis.auth = conn_info.auth.replace(/.*?:/, '');
-    }
-
+  // support legacy passthrough of options
+  if( options.redis && options.redis.options ) {
+    Object.assign(options.redis, options.redis.options)
   }
 
   options.redis = options.redis || {};
@@ -109,17 +97,7 @@ exports.configureFactory = function( options, queue ) {
 
 exports.createClientFactory = function( options ) {
   var socket = options.redis.socket;
-  var port   = !socket ? (options.redis.port || 6379) : null;
-  var host   = !socket ? (options.redis.host || '127.0.0.1') : null;
-  var db   = !socket ? (options.redis.db || 0) : null;
-  var client = redis.createClient(socket || port, host, options.redis.options);
-  if( options.redis.auth ) {
-    client.auth(options.redis.auth);
-  }
-  if( db >= 0 ){
-    client.select(db);
-  }
-  return client;
+  return redis.createClient(socket || options.redis);
 };
 
 /**

--- a/test/tdd/redis.spec.js
+++ b/test/tdd/redis.spec.js
@@ -14,16 +14,6 @@ describe('redis', function() {
       redis.reset.restore();
     });
 
-    it('should parse a url connection string', function () {
-      var options = {
-        redis: 'redis://:password@host:1234/db'
-      };
-      redis.configureFactory(options);
-      options.redis.port.should.equal('1234');
-      options.redis.host.should.equal('host');
-      options.redis.db.should.equal('db');
-    });
-
     it('should reset everything', function () {
       var options = {
         redis: 'redis://:password@host:1234/db'
@@ -110,49 +100,6 @@ describe('redis', function() {
         var id = client.stripFIFO( '03|123' );
         id.should.equal(123);
       });
-    });
-
-  });
-
-  describe('Function: createClientFactory', function() {
-    var options, client;
-    beforeEach(function(){
-      options = {
-        prefix: 'prefix',
-        redis: {
-          port: 'port',
-          host: 'host',
-          db: 'db',
-          options: {}
-        }
-      };
-      client = {
-        auth: sinon.stub(),
-        select: sinon.stub()
-      };
-      sinon.stub(r, 'createClient').returns(client);
-    });
-
-    afterEach(function(){
-      r.createClient.restore();
-    });
-
-    it('should create a client', function () {
-      var c = redis.createClientFactory(options);
-      r.createClient.called.should.be.true;
-      r.createClient.calledWith(options.redis.port, options.redis.host, options.redis.options).should.be.true;
-    });
-
-    it('should authenticate if auth is present', function () {
-      options.redis.auth = 'auth';
-      var c = redis.createClientFactory(options);
-      client.auth.calledWith(options.redis.auth).should.be.true;
-    });
-
-    it('should select the passed in db', function () {
-      options.redis.db = 1;
-      var c = redis.createClientFactory(options);
-      client.select.calledWith(options.redis.db).should.be.true;
     });
 
   });

--- a/test/test.js
+++ b/test/test.js
@@ -66,56 +66,6 @@ describe('CONNECTION', function(){
 		} );
 	});
 
-	it( 'should default to 0 db with string', function ( done ) {
-		var jobs = new kue( {
-			redis: 'redis://localhost:6379/?foo=bar'
-		} );
-
-		jobs.client.options.port.should.be.eql( 6379 );
-		jobs.client.options.host.should.be.eql( 'localhost' );
-		jobs.client.options.foo.should.be.eql( 'bar' );
-
-		var jobData = {
-			title: 'welcome email for tj',
-			to: '"TJ" <tj@learnboost.com>',
-			template: 'welcome-email'
-		};
-		jobs.create( 'email-should-be-processed-5', jobData ).priority( 'high' ).save();
-		jobs.process( 'email-should-be-processed-5', function ( job, jdone ) {
-			job.data.should.be.eql( jobData );
-			job.log( '<p>This is <span style="color: green;">a</span> formatted log<p/>' );
-			jobs.client.selected_db.should.be.eql(0);
-			jdone();
-			done();
-		} );
-
-	});
-
-	it( 'should default to 0 db with string and no /', function ( done ) {
-		var jobs = new kue( {
-			redis: 'redis://localhost:6379?foo=bar'
-		} );
-
-		jobs.client.options.port.should.be.eql( 6379 );
-		jobs.client.options.host.should.be.eql( 'localhost' );
-		jobs.client.options.foo.should.be.eql( 'bar' );
-
-		var jobData = {
-			title: 'welcome email for tj',
-			to: '"TJ" <tj@learnboost.com>',
-			template: 'welcome-email'
-		};
-		jobs.create( 'email-should-be-processed-6', jobData ).priority( 'high' ).save();
-		jobs.process( 'email-should-be-processed-6', function ( job, jdone ) {
-			job.data.should.be.eql( jobData );
-			job.log( '<p>This is <span style="color: green;">a</span> formatted log<p/>' );
-			jobs.client.selected_db.should.be.eql(0);
-			jdone();
-			done();
-		} );
-
-	});
-
 	it( 'should configure properly with dictionary', function ( done ) {
 		jobs = new kue( {
 			redis: {
@@ -141,7 +91,6 @@ describe('CONNECTION', function(){
 			job.data.should.be.eql( jobData );
 			job.log( '<p>This is <span style="color: green;">a</span> formatted log<p/>' );
 			// Needs to be here to support the async client.select statement where the return happens sync but the call is async
-			jobs.client.selected_db.should.be.eql(0);
 			jdone();
 			done();
 		} );


### PR DESCRIPTION
Use case - I would like to use a redis configuration like
```{ url: 'my-connection-url', tls: { servername: 'my-servername' } }```

This is the easiest configuration for Microsoft Azure's fully managed redis.  While it's possible to support this with the existing configuration it requires de-structuring the connection url, passing it through to Kue where it will be re-constructed and passed back. With this PR, the same opts can be provided to the redis.createClient() function as go to Kue.

To maintain compatibility, I've translated the options.redis.socket to the "path" argument passed to redis & I took the options.redis.options and spread them into the main configuration, so they should still be supported.