### PR TITLE
Fix Bug job ttl-exceeded still in active set after failed it

### DIFF
--- a/lib/kue.js
+++ b/lib/kue.js
@@ -248,6 +248,9 @@ Queue.prototype.checkActiveJobTtl = function( ttlOptions ) {
           }, 1000 );
 
           ids.forEach(function( id ) {
+            // delete ttl exceeded job from active set befored failed
+            client.zrem(client.getKey('jobs:active'), id, function (err, count) {
+            });
             id = client.stripFIFO(id);
             events.emit(id, 'ttl exceeded');
           });


### PR DESCRIPTION
job ttl-exceeded still in active set after failed it。