### PR TITLE
Allow for an option to set the body-parser limit configuration

### DIFF
--- a/lib/http/index.js
+++ b/lib/http/index.js
@@ -62,7 +62,7 @@ app.get('/job/:id/log', provides('json'), json.log);
 app.put('/job/:id/state/:state', provides('json'), json.updateState);
 app.put('/job/:id/priority/:priority', provides('json'), json.updatePriority);
 app.delete('/job/:id', provides('json'), json.remove);
-app.post('/job', provides('json'), bodyParser.json(), json.createJob);
+app.post('/job', provides('json'), process.env.BODY_PARSER_LIMIT ? bodyParser.json({ limit: process.env.BODY_PARSER_LIMIT }) : bodyParser.json(), json.createJob);
 app.get('/inactive/:id', provides('json'), json.inactive);
 
 // routes


### PR DESCRIPTION
We are running into an issue where we need to adjust the body size, but Kue only implements body-parser with default options. This would allow for an environment variable to be set with the custom limit.