### PR TITLE
Deprecation notice

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,9 @@
 # Kue
 
+## Kue is no longer maintained
+
+Please see e.g. [Bull](https://github.com/OptimalBits/bull) as an alternative. Thank you!
+
 [![Build Status](https://travis-ci.org/Automattic/kue.svg?branch=master&style=flat)](https://travis-ci.org/Automattic/kue)
 [![npm version](https://badge.fury.io/js/kue.svg?style=flat)](http://badge.fury.io/js/kue)
 [![Dependency Status](https://img.shields.io/david/Automattic/kue.svg?style=flat)](https://david-dm.org/Automattic/kue)


### PR DESCRIPTION
As per convo https://github.com/Automattic/kue/issues/1196

Happy to add also [Bee](https://github.com/bee-queue/bee-queue) and [Agenda](https://github.com/Agenda/agenda) for more choice but they're less actively maintained than Bull. I'm also one of the (less active) maintainers of Agenda so I'm biassed. :-)

If you'd prefer to seek for maintainers instead, let me know and what you reckon should be the timeline before deprecating instead.

This came up again in https://twitter.com/andychilton/status/1138918911578001408

Resolves https://github.com/Automattic/kue/issues/1230