### PR TITLE
encodeURI filter

### DIFF
--- a/lib/http/public/javascripts/main.js
+++ b/lib/http/public/javascripts/main.js
@@ -181,7 +181,7 @@ function refreshJobs(state, fn) {
         , visibleFrom = Math.max(0, Math.floor(top / jobHeight))
         , visibleTo = Math.floor((top + height) / jobHeight)
         , url = './jobs/'
-            + (filter ? filter + '/' : '')
+            + (filter ? encodeURIComponent(filter) + '/' : '')
             + state + '/0..' + to
             + '/' + sort;
 


### PR DESCRIPTION
When the filter contains a special symbol (for example: '/'), it will cause an error.
my case:  /jobs/email(2/5)/failed/0..10/asc,the filter is 'email(2/5)'